### PR TITLE
add security-token as available subresource

### DIFF
--- a/oss2/auth.py
+++ b/oss2/auth.py
@@ -18,7 +18,7 @@ class Auth(object):
          'acl', 'uploadId', 'uploads', 'partNumber', 'group', 'link',
          'delete', 'website', 'location', 'objectInfo',
          'response-expires', 'response-content-disposition', 'cors', 'lifecycle',
-          'restore', 'qos', 'referer', 'append', 'position']
+          'restore', 'qos', 'referer', 'append', 'position', 'security-token']
     )
 
     def __init__(self, access_key_id, access_key_secret):


### PR DESCRIPTION
add security-token as available subresource when computing canonicalized resources since signing in URL with STS tokens need it.
When I use
```
bucket.sign_url('GET', 'img/aaa.jpg', 5 * 60, params=headers)
```
to generate a URL for external access, it failed me if I sign this URL with AccessKeyId, AccessKeySecret and security-token I've got via STS. According to STS SDK document, when signing in URl with STS security token, 'security-token' should be considered as a sub-resource. But it was not listed in available sub-resources in current code base.