### PR TITLE
修复缺省参数无法改变的问题；connect time设为60秒；

### DIFF
--- a/oss2/api.py
+++ b/oss2/api.py
@@ -198,7 +198,7 @@ class Service(_Base):
         resp = self._do('GET', '', '',
                         params={'prefix': prefix,
                                 'marker': marker,
-                                'max-keys': max_keys})
+                                'max-keys': str(max_keys)})
         return self._parse_result(resp, xml_utils.parse_list_buckets, ListBucketsResult)
 
 
@@ -287,7 +287,7 @@ class Bucket(_Base):
                                 params={'prefix': prefix,
                                         'delimiter': delimiter,
                                         'marker': marker,
-                                        'max-keys': max_keys,
+                                        'max-keys': str(max_keys),
                                         'encoding-type': 'url'})
         return self._parse_result(resp, xml_utils.parse_list_objects, ListObjectsResult)
 
@@ -643,7 +643,7 @@ class Bucket(_Base):
                                         'delimiter': delimiter,
                                         'key-marker': key_marker,
                                         'upload-id-marker': upload_id_marker,
-                                        'max-uploads': max_uploads,
+                                        'max-uploads': str(max_uploads),
                                         'encoding-type': 'url'})
         return self._parse_result(resp, xml_utils.parse_list_multipart_uploads, ListMultipartUploadsResult)
 

--- a/oss2/api.py
+++ b/oss2/api.py
@@ -131,7 +131,7 @@ class _Base(object):
         self.auth = auth
         self.endpoint = _normalize_endpoint(endpoint.strip())
         self.session = session or http.Session()
-        self.timeout = connect_timeout
+        self.timeout = defaults.get(connect_timeout, defaults.connect_timeout)
         self.app_name = app_name
 
         self._make_url = _UrlMaker(self.endpoint, is_cname)
@@ -180,7 +180,7 @@ class Service(_Base):
     """
     def __init__(self, auth, endpoint,
                  session=None,
-                 connect_timeout=defaults.connect_timeout,
+                 connect_timeout=None,
                  app_name=''):
         super(Service, self).__init__(auth, endpoint, False, session, connect_timeout,
                                       app_name=app_name)
@@ -240,7 +240,7 @@ class Bucket(_Base):
     def __init__(self, auth, endpoint, bucket_name,
                  is_cname=False,
                  session=None,
-                 connect_timeout=defaults.connect_timeout,
+                 connect_timeout=None,
                  app_name=''):
         super(Bucket, self).__init__(auth, endpoint, is_cname, session, connect_timeout,
                                      app_name=app_name)

--- a/oss2/defaults.py
+++ b/oss2/defaults.py
@@ -17,7 +17,7 @@ def get(value, default_value):
 
 
 #: 连接超时时间
-connect_timeout = 10
+connect_timeout = 60
 
 #: 缺省重试次数
 request_retries = 3

--- a/oss2/defaults.py
+++ b/oss2/defaults.py
@@ -8,6 +8,14 @@ oss2.defaults
 
 """
 
+
+def get(value, default_value):
+    if value is None:
+        return default_value
+    else:
+        return value
+
+
 #: 连接超时时间
 connect_timeout = 10
 

--- a/oss2/iterators.py
+++ b/oss2/iterators.py
@@ -160,7 +160,7 @@ class ObjectUploadIterator(_BaseIterator):
     :param key: 文件名
     :param max_uploads: 每次调用 `list_multipart_uploads` 时的max_uploads参数。注意迭代器返回的数目可能会大于该值。
     """
-    def __init__(self, bucket, key, max_uploads=1000, max_retries=defaults.request_retries):
+    def __init__(self, bucket, key, max_uploads=1000, max_retries=None):
         super(ObjectUploadIterator, self).__init__('', max_retries)
         self.bucket = bucket
         self.key = key
@@ -195,7 +195,7 @@ class PartIterator(_BaseIterator):
     :param max_parts: 每次调用 `list_parts` 时的max_parts参数。注意迭代器返回的数目可能会大于该值。
     """
     def __init__(self, bucket, key, upload_id,
-                 marker='0', max_parts=1000, max_retries=defaults.request_retries):
+                 marker='0', max_parts=1000, max_retries=None):
         super(PartIterator, self).__init__(marker, max_retries)
 
         self.bucket = bucket

--- a/oss2/iterators.py
+++ b/oss2/iterators.py
@@ -17,6 +17,8 @@ class _BaseIterator(object):
     def __init__(self, marker, max_retries):
         self.is_truncated = True
         self.next_marker = marker
+
+        max_retries = defaults.get(max_retries, defaults.request_retries)
         self.max_retries = max_retries if max_retries > 0 else 1
 
         self.entries = []
@@ -64,7 +66,7 @@ class BucketIterator(_BaseIterator):
     :param marker: 分页符。只列举Bucket名字典序在此之后的Bucket
     :param max_keys: 每次调用 `list_buckets` 时的max_keys参数。注意迭代器返回的数目可能会大于该值。
     """
-    def __init__(self, service, prefix='', marker='', max_keys=100, max_retries=defaults.request_retries):
+    def __init__(self, service, prefix='', marker='', max_keys=100, max_retries=None):
         super(BucketIterator, self).__init__(marker, max_retries)
         self.service = service
         self.prefix = prefix
@@ -91,7 +93,7 @@ class ObjectIterator(_BaseIterator):
     :param marker: 分页符
     :param max_keys: 每次调用 `list_objects` 时的max_keys参数。注意迭代器返回的数目可能会大于该值。
     """
-    def __init__(self, bucket, prefix='', delimiter='', marker='', max_keys=100, max_retries=defaults.request_retries):
+    def __init__(self, bucket, prefix='', delimiter='', marker='', max_keys=100, max_retries=None):
         super(ObjectIterator, self).__init__(marker, max_retries)
 
         self.bucket = bucket
@@ -126,7 +128,7 @@ class MultipartUploadIterator(_BaseIterator):
     """
     def __init__(self, bucket,
                  prefix='', delimiter='', key_marker='', upload_id_marker='',
-                 max_uploads=1000, max_retries=defaults.request_retries):
+                 max_uploads=1000, max_retries=None):
         super(MultipartUploadIterator, self).__init__(key_marker, max_retries)
 
         self.bucket = bucket

--- a/oss2/resumable.py
+++ b/oss2/resumable.py
@@ -27,7 +27,7 @@ _MIN_PART_SIZE = 100 * 1024
 def resumable_upload(bucket, key, filename,
                      store=None,
                      headers=None,
-                     multipart_threshold=defaults.multipart_threshold,
+                     multipart_threshold=None,
                      part_size=None,
                      progress_callback=None):
     """断点上传本地文件。
@@ -45,6 +45,7 @@ def resumable_upload(bucket, key, filename,
     :param progress_callback: 上传进度回调函数。参见 :ref:`progress_callback` 。
     """
     size = os.path.getsize(filename)
+    multipart_threshold = defaults.get(multipart_threshold, defaults.multipart_threshold)
 
     if size >= multipart_threshold:
         uploader = _ResumableUploader(bucket, key, filename, size, store,
@@ -99,7 +100,7 @@ class _ResumableUploader(object):
     def __init__(self, bucket, key, filename, size,
                  store=None,
                  headers=None,
-                 part_size=defaults.part_size,
+                 part_size=None,
                  progress_callback=None):
         self.bucket = bucket
         self.key = key
@@ -108,7 +109,7 @@ class _ResumableUploader(object):
 
         self.store = store or ResumableStore()
         self.headers = headers
-        self.part_size = part_size
+        self.part_size = defaults.get(part_size, defaults.part_size)
 
         self.abspath = os.path.abspath(filename)
         self.mtime = os.path.getmtime(filename)

--- a/tests/common.py
+++ b/tests/common.py
@@ -38,8 +38,11 @@ class OssTestCase(unittest.TestCase):
         super(OssTestCase, self).__init__(*args, **kwargs)
         self.bucket = None
         self.prefix = random_string(12)
+        self.default_connect_timeout = oss2.defaults.connect_timeout
 
     def setUp(self):
+        oss2.defaults.connect_timeout = self.default_connect_timeout
+
         self.bucket = oss2.Bucket(oss2.Auth(OSS_ID, OSS_SECRET), OSS_ENDPOINT, OSS_BUCKET)
         self.bucket.create_bucket()
         self.key_list = []

--- a/tests/test_iterator.py
+++ b/tests/test_iterator.py
@@ -13,6 +13,7 @@ class TestIterator(OssTestCase):
     def test_bucket_iterator(self):
         service = oss2.Service(oss2.Auth(OSS_ID, OSS_SECRET), OSS_ENDPOINT)
         self.assertTrue(OSS_BUCKET in (b.name for b in oss2.BucketIterator(service, max_keys=2)))
+        self.assertTrue(OSS_BUCKET in list(b.name for b in oss2.BucketIterator(service, max_keys=2)))
 
     def test_object_iterator(self):
         prefix = self.random_key('/')

--- a/tests/test_object.py
+++ b/tests/test_object.py
@@ -153,6 +153,11 @@ class TestObject(OssTestCase):
                              connect_timeout=0.001)
         self.assertRaises(RequestError, bucket.get_bucket_acl)
 
+    def test_default_timeout(self):
+        oss2.defaults.connect_timeout = 0.001
+        bucket = oss2.Bucket(oss2.Auth(OSS_ID, OSS_SECRET), OSS_ENDPOINT, OSS_BUCKET)
+        self.assertRaises(RequestError, bucket.get_bucket_acl)
+
     def test_get_object_iterator(self):
         key = self.random_key()
         content = random_bytes(1024 * 1024)

--- a/unittests/common.py
+++ b/unittests/common.py
@@ -114,7 +114,7 @@ def r4put(in_status=200, in_headers=None):
 
 
 def r4copy():
-    body = b'''
+    body = '''
     <?xml version="1.0" encoding="UTF-8"?>
     <CopyObjectResult>
         <ETag>"{0}"</ETag>
@@ -276,7 +276,19 @@ class MockResponse(object):
 
 
 class OssTestCase(unittest.TestCase):
+    def __init__(self, *args, **kwargs):
+        super(OssTestCase, self).__init__(*args, **kwargs)
+        self.default_connect_timeout = oss2.defaults.connect_timeout
+        self.default_request_retries = oss2.defaults.request_retries
+        self.default_multipart_threshold = oss2.defaults.multipart_threshold
+        self.default_part_size = oss2.defaults.part_size
+
     def setUp(self):
+        oss2.defaults.connect_timeout = self.default_connect_timeout
+        oss2.defaults.request_retries = self.default_request_retries
+        oss2.defaults.multipart_threshold = self.default_multipart_threshold
+        oss2.defaults.part_size = self.default_part_size
+
         self.previous = -1
         self.temp_files = []
 

--- a/unittests/common.py
+++ b/unittests/common.py
@@ -14,6 +14,7 @@ CHUNK_SIZE = 8192
 
 BUCKET_NAME = 'my-bucket'
 
+
 def random_string(n):
     return ''.join(random.choice(string.ascii_lowercase) for i in range(n))
 
@@ -25,6 +26,11 @@ def random_bytes(n):
 def bucket():
     return oss2.Bucket(oss2.Auth('fake-access-key-id', 'fake-access-key-secret'),
                                   'http://oss-cn-hangzhou.aliyuncs.com', BUCKET_NAME)
+
+
+def service():
+    return oss2.Service(oss2.Auth('fake-access-key-id', 'fake-access-key-secret'),
+                        'http://oss-cn-hangzhou.aliyuncs.com')
 
 
 class RequestInfo(object):
@@ -146,6 +152,27 @@ def do4body(req, timeout,
         req_info.resp = resp
 
     return resp
+
+
+class NonlocalObject(object):
+    def __init__(self, value):
+        self.var = value
+
+
+def make_do4body(req_infos=None, body_list=None):
+    if req_infos is None:
+        req_infos = [None] * len(body_list)
+
+    i = NonlocalObject(0)
+
+    def do4body_func(req, timeout):
+        result = do4body(req, timeout,
+                         req_info=req_infos[i.var],
+                         body=body_list[i.var])
+        i.var += 1
+        return result
+
+    return do4body_func
 
 
 def do4put(req, timeout, in_headers=None, req_info=None, data_type=DT_BYTES):

--- a/unittests/common.py
+++ b/unittests/common.py
@@ -4,6 +4,8 @@ import random
 import string
 import unittest
 import tempfile
+import os
+
 from xml.dom import minidom
 
 import oss2

--- a/unittests/test_bucket.py
+++ b/unittests/test_bucket.py
@@ -319,10 +319,10 @@ class TestBucket(OssTestCase):
     def test_put_referer(self, do_request):
         from oss2.models import BucketReferer
 
-        body = b'<RefererConfiguration><AllowEmptyReferer>true</AllowEmptyReferer>' + \
-            b'<RefererList><Referer>http://hello.com</Referer>' + \
-            b'<Referer>mibrowser:home</Referer>' + \
-            b'<Referer>阿里巴巴</Referer></RefererList></RefererConfiguration>'
+        body = '<RefererConfiguration><AllowEmptyReferer>true</AllowEmptyReferer>' + \
+            '<RefererList><Referer>http://hello.com</Referer>' + \
+            '<Referer>mibrowser:home</Referer>' + \
+            '<Referer>阿里巴巴</Referer></RefererList></RefererConfiguration>'
 
         req_info = RequestInfo()
         do_request.auto_spec = True
@@ -333,10 +333,10 @@ class TestBucket(OssTestCase):
 
     @patch('oss2.Session.do_request')
     def test_get_referer(self, do_request):
-        body = b'<RefererConfiguration><AllowEmptyReferer>false</AllowEmptyReferer>' + \
-            b'<RefererList><Referer>http://hello.com</Referer>' + \
-            b'<Referer>mibrowser:home</Referer>' + \
-            b'<Referer>阿里巴巴</Referer></RefererList></RefererConfiguration>'
+        body = '<RefererConfiguration><AllowEmptyReferer>false</AllowEmptyReferer>' + \
+            '<RefererList><Referer>http://hello.com</Referer>' + \
+            '<Referer>mibrowser:home</Referer>' + \
+            '<Referer>阿里巴巴</Referer></RefererList></RefererConfiguration>'
 
         do_request.return_value = r4get_meta(body)
 

--- a/unittests/test_iterator.py
+++ b/unittests/test_iterator.py
@@ -407,6 +407,46 @@ class TestIterator(OssTestCase):
         got = list(oss2.MultipartUploadIterator(bucket(), max_uploads=1000))
         self.assertEqual(len(got), 0)
 
+    def test_part_iterator_default_max_retries(self):
+        iter = oss2.PartIterator(bucket(), 'fake-key', 'fake-upload-id')
+        self.assertEqual(iter.max_retries, oss2.defaults.request_retries)
 
+        oss2.defaults.request_retries = 100
+        iter = oss2.PartIterator(bucket(), 'fake-key', 'fake-upload-id')
+        self.assertEqual(iter.max_retries, 100)
 
+        iter = oss2.PartIterator(bucket(), 'fake-key', 'fake-upload-id', max_retries=1)
+        self.assertEqual(iter.max_retries, 1)
 
+    def test_object_iterator_default_max_retries(self):
+        iter = oss2.ObjectIterator(bucket())
+        self.assertEqual(iter.max_retries, oss2.defaults.request_retries)
+
+        oss2.defaults.request_retries = 100
+        iter = oss2.ObjectIterator(bucket())
+        self.assertEqual(iter.max_retries, 100)
+
+        iter = oss2.ObjectIterator(bucket(), max_retries=1)
+        self.assertEqual(iter.max_retries, 1)
+
+    def test_bucket_iterator_default_max_retries(self):
+        iter = oss2.BucketIterator(service())
+        self.assertEqual(iter.max_retries, oss2.defaults.request_retries)
+
+        oss2.defaults.request_retries = 100
+        iter = oss2.BucketIterator(service())
+        self.assertEqual(iter.max_retries, 100)
+
+        iter = oss2.BucketIterator(service(), max_retries=1)
+        self.assertEqual(iter.max_retries, 1)
+
+    def test_object_upload_iterator_default_max_retries(self):
+        iter = oss2.ObjectUploadIterator(bucket(), 'fake-key')
+        self.assertEqual(iter.max_retries, oss2.defaults.request_retries)
+
+        oss2.defaults.request_retries = 100
+        iter = oss2.ObjectUploadIterator(bucket(), 'fake-key')
+        self.assertEqual(iter.max_retries, 100)
+
+        iter = oss2.ObjectUploadIterator(bucket(), 'fake-key', max_retries=1)
+        self.assertEqual(iter.max_retries, 1)

--- a/unittests/test_iterator.py
+++ b/unittests/test_iterator.py
@@ -3,14 +3,17 @@
 from mock import patch
 from common import *
 
-from oss2.models import SimplifiedBucketInfo
+from oss2.models import SimplifiedBucketInfo, SimplifiedObjectInfo
+from oss2 import to_string
 
 
 class TestIterator(OssTestCase):
-    def assertBucketEqual(self, a, b):
-        self.assertEqual(a.name, b.name)
-        self.assertEqual(a.location, b.location)
-        self.assertEqual(a.creation_date, b.creation_date)
+    def assertInstanceEqual(self, a, b):
+        adict = vars(a)
+        bdict = vars(b)
+
+        for k, v in adict.items():
+            self.assertEqual(adict[k], bdict[k])
 
     @patch('oss2.Session.do_request')
     def test_bucket_iterator_not_truncated(self, do_request):
@@ -46,8 +49,8 @@ class TestIterator(OssTestCase):
         got = list(oss2.BucketIterator(service()))
 
         self.assertEqual(len(expected), len(got))
-        self.assertBucketEqual(expected[0], got[0])
-        self.assertBucketEqual(expected[1], got[1])
+        self.assertInstanceEqual(expected[0], got[0])
+        self.assertInstanceEqual(expected[1], got[1])
 
         self.assertEqual(req_info.req.params.get('prefix', ''), '')
         self.assertEqual(req_info.req.params.get('marker', ''), '')
@@ -147,7 +150,7 @@ class TestIterator(OssTestCase):
         self.assertEqual(len(expected), len(got))
 
         for i in range(len(got)):
-            self.assertBucketEqual(expected[i], got[i])
+            self.assertInstanceEqual(expected[i], got[i])
 
         for i in range(nreq):
             self.assertEqual(req_infos[i].req.params.get('max-keys'), '2')
@@ -156,3 +159,254 @@ class TestIterator(OssTestCase):
         self.assertEqual(req_infos[0].req.params.get('marker', ''), '')
         self.assertEqual(req_infos[1].req.params.get('marker', ''), 'ming-oss-share')
         self.assertEqual(req_infos[2].req.params.get('marker', ''), 'ming-spike')
+
+    @patch('oss2.Session.do_request')
+    def test_object_iterator_empty(self, do_request):
+        body_list = [b'''<?xml version="1.0" encoding="UTF-8"?>
+        <ListBucketResult>
+          <Name>ming-bj</Name>
+          <Prefix></Prefix>
+          <Marker></Marker>
+          <MaxKeys>1000</MaxKeys>
+          <Delimiter></Delimiter>
+          <EncodingType>url</EncodingType>
+          <IsTruncated>false</IsTruncated>
+        </ListBucketResult>''']
+
+        do_request.auto_spec = True
+        do_request.side_effect = make_do4body(body_list=body_list)
+
+        got = list(oss2.ObjectIterator(bucket(), max_keys=1000))
+        self.assertEqual(len(got), 0)
+
+    @patch('oss2.Session.do_request')
+    def test_object_iterator_not_truncated(self, do_request):
+        body_list = [b'''<?xml version="1.0" encoding="UTF-8"?>
+        <ListBucketResult>
+          <Name>zzy-share</Name>
+          <Prefix></Prefix>
+          <Marker></Marker>
+          <MaxKeys>1000</MaxKeys>
+          <Delimiter></Delimiter>
+          <IsTruncated>false</IsTruncated>
+          <Contents>
+            <Key>object-1</Key>
+            <LastModified>2015-02-02T05:15:13.000Z</LastModified>
+            <ETag>"716AF6FFD529DFEA856FAA4E12D2C5EA"</ETag>
+            <Type>Normal</Type>
+            <Size>4308</Size>
+            <StorageClass>Standard</StorageClass>
+            <Owner>
+              <ID>1047205513514293</ID>
+              <DisplayName>1047205513514293</DisplayName>
+            </Owner>
+          </Contents>
+          <Contents>
+            <Key>object-2</Key>
+            <LastModified>2015-06-23T09:56:55.000Z</LastModified>
+            <ETag>"333D74B47CB1B0E275D2AB3CDDA02665-26"</ETag>
+            <Type>Multipart</Type>
+            <Size>3389246</Size>
+            <StorageClass>Standard</StorageClass>
+            <Owner>
+              <ID>1047205513514293</ID>
+              <DisplayName>1047205513514293</DisplayName>
+            </Owner>
+          </Contents>
+          <Contents>
+            <Key>object-3</Key>
+            <LastModified>2015-01-16T12:41:34.000Z</LastModified>
+            <ETag>"B28F7255E6EA777DB0AFB1C58C2CFCFE"</ETag>
+            <Type>Normal</Type>
+            <Size>10718416</Size>
+            <StorageClass>Standard</StorageClass>
+            <Owner>
+              <ID>1047205513514293</ID>
+              <DisplayName>1047205513514293</DisplayName>
+            </Owner>
+          </Contents>
+        </ListBucketResult>
+        ''']
+
+        req_info = RequestInfo()
+
+        do_request.auto_spec = True
+        do_request.side_effect = make_do4body(req_infos=[req_info], body_list=body_list)
+
+        got = list(oss2.ObjectIterator(bucket(), max_keys=1000))
+
+        expected = [SimplifiedObjectInfo('object-1', 1422854113, '716AF6FFD529DFEA856FAA4E12D2C5EA', 'Normal', 4308, 'Standard'),
+                    SimplifiedObjectInfo('object-2', 1435053415, '333D74B47CB1B0E275D2AB3CDDA02665-26', 'Multipart', 3389246, 'Standard'),
+                    SimplifiedObjectInfo('object-3', 1421412094, 'B28F7255E6EA777DB0AFB1C58C2CFCFE', 'Normal', 10718416, 'Standard')]
+
+        self.assertEqual(len(expected), len(got))
+
+        for i in range(len(expected)):
+            self.assertInstanceEqual(expected[i], got[i])
+
+        self.assertEqual(req_info.req.params.get('prefix', ''), '')
+        self.assertEqual(req_info.req.params.get('marker', ''), '')
+        self.assertEqual(req_info.req.params.get('encoding-type'), 'url')
+
+    @patch('oss2.Session.do_request')
+    def test_object_iterator_truncated(self, do_request):
+        body_list = [b'''<?xml version="1.0" encoding="UTF-8"?>
+        <ListBucketResult>
+          <Name>ming-spike</Name>
+          <Prefix></Prefix>
+          <Marker></Marker>
+          <MaxKeys>1</MaxKeys>
+          <Delimiter></Delimiter>
+          <EncodingType>url</EncodingType>
+          <IsTruncated>true</IsTruncated>
+          <NextMarker>a.txt</NextMarker>
+          <Contents>
+            <Key>a.txt</Key>
+            <LastModified>2016-01-07T11:10:00.000Z</LastModified>
+            <ETag>"5EB63BBBE01EEED093CB22BB8F5ACDC3"</ETag>
+            <Type>Normal</Type>
+            <Size>11</Size>
+            <StorageClass>Standard</StorageClass>
+            <Owner>
+              <ID>1047205513514293</ID>
+              <DisplayName>1047205513514293</DisplayName>
+            </Owner>
+          </Contents>
+        </ListBucketResult>''',
+        b'''<?xml version="1.0" encoding="UTF-8"?>
+        <ListBucketResult>
+          <Name>ming-spike</Name>
+          <Prefix></Prefix>
+          <Marker>a.txt</Marker>
+          <MaxKeys>1</MaxKeys>
+          <Delimiter></Delimiter>
+          <EncodingType>url</EncodingType>
+          <IsTruncated>true</IsTruncated>
+          <NextMarker>%E4%B8%AD%E6%96%87.txt</NextMarker>
+          <Contents>
+            <Key>%E4%B8%AD%E6%96%87.txt</Key>
+            <LastModified>2016-01-07T11:09:39.000Z</LastModified>
+            <ETag>"FC3FF98E8C6A0D3087D515C0473F8677"</ETag>
+            <Type>Normal</Type>
+            <Size>12</Size>
+            <StorageClass>Standard</StorageClass>
+            <Owner>
+              <ID>1047205513514293</ID>
+              <DisplayName>1047205513514293</DisplayName>
+            </Owner>
+          </Contents>
+        </ListBucketResult>''',
+        b'''<?xml version="1.0" encoding="UTF-8"?>
+        <ListBucketResult>
+          <Name>ming-spike</Name>
+          <Prefix></Prefix>
+          <Marker>%E4%B8%AD%E6%96%87.txt</Marker>
+          <MaxKeys>1</MaxKeys>
+          <Delimiter></Delimiter>
+          <EncodingType>url</EncodingType>
+          <IsTruncated>false</IsTruncated>
+          <Contents>
+            <Key>%E9%98%BF%E9%87%8C%E4%BA%91.txt</Key>
+            <LastModified>2016-01-07T11:07:32.000Z</LastModified>
+            <ETag>"5D41402ABC4B2A76B9719D911017C592"</ETag>
+            <Type>Normal</Type>
+            <Size>5</Size>
+            <StorageClass>Standard</StorageClass>
+            <Owner>
+              <ID>1047205513514293</ID>
+              <DisplayName>1047205513514293</DisplayName>
+            </Owner>
+          </Contents>
+        </ListBucketResult>''']
+
+        expected = [SimplifiedObjectInfo('a.txt', 1452165000, '5EB63BBBE01EEED093CB22BB8F5ACDC3', 'Normal', 11, 'Standard'),
+                    SimplifiedObjectInfo('中文.txt', 1452164979, 'FC3FF98E8C6A0D3087D515C0473F8677', 'Normal', 12, 'Standard'),
+                    SimplifiedObjectInfo('阿里云.txt', 1452164852, '5D41402ABC4B2A76B9719D911017C592', 'Normal', 5, 'Standard')]
+
+        nreq = 3
+
+        req_infos = [RequestInfo() for i in range(nreq)]
+
+        do_request.auto_spec = True
+        do_request.side_effect = make_do4body(req_infos=req_infos, body_list=body_list)
+
+        got = list(oss2.ObjectIterator(bucket(), max_keys=1))
+
+        for i in range(len(expected)):
+            self.assertInstanceEqual(expected[i], got[i])
+
+        for i in range(nreq):
+            self.assertEqual(req_infos[i].req.params.get('prefix', ''), '')
+            self.assertEqual(req_infos[i].req.params.get('max-keys', ''), '1')
+            self.assertEqual(req_infos[i].req.params.get('delimiter', ''), '')
+            self.assertEqual(req_infos[i].req.params.get('encoding-type', ''), 'url')
+
+        self.assertEqual(req_infos[0].req.params.get('marker', ''), '')
+        self.assertEqual(req_infos[1].req.params.get('marker', ''), 'a.txt')
+        self.assertEqual(req_infos[2].req.params.get('marker', ''), '中文.txt')
+
+    @patch('oss2.Session.do_request')
+    def test_object_iterator_dir(self, do_request):
+        body_list=[b'''<?xml version="1.0" encoding="UTF-8"?>
+        <ListBucketResult>
+          <Name>ming-spike</Name>
+          <Prefix></Prefix>
+          <Marker></Marker>
+          <MaxKeys>1000</MaxKeys>
+          <Delimiter>%2F</Delimiter>
+          <EncodingType>url</EncodingType>
+          <IsTruncated>false</IsTruncated>
+          <Contents>
+            <Key>a.txt</Key>
+            <LastModified>2016-01-07T11:10:00.000Z</LastModified>
+            <ETag>"5EB63BBBE01EEED093CB22BB8F5ACDC3"</ETag>
+            <Type>Normal</Type>
+            <Size>11</Size>
+            <StorageClass>Standard</StorageClass>
+            <Owner>
+              <ID>1047205513514293</ID>
+              <DisplayName>1047205513514293</DisplayName>
+            </Owner>
+          </Contents>
+          <CommonPrefixes>
+            <Prefix>%E6%96%87%E4%BB%B6%2F</Prefix>
+          </CommonPrefixes>
+        </ListBucketResult>''']
+
+        expected = [SimplifiedObjectInfo('a.txt', 1452165000, '5EB63BBBE01EEED093CB22BB8F5ACDC3', 'Normal', 11, 'Standard'),
+                    SimplifiedObjectInfo('文件/', None, None, None, None, None)]
+
+        req_info = RequestInfo()
+        do_request.auto_spec = True
+        do_request.side_effect = make_do4body(req_infos=[req_info], body_list=body_list)
+
+        got = list(oss2.ObjectIterator(bucket(), max_keys=1000))
+
+        for i in range(len(expected)):
+            self.assertInstanceEqual(expected[i], got[i])
+
+    @patch('oss2.Session.do_request')
+    def test_upload_iterator_empty(self, do_request):
+        body_list = [b'''<?xml version="1.0" encoding="UTF-8"?>
+        <ListMultipartUploadsResult>
+          <EncodingType>url</EncodingType>
+          <Bucket>ming-spike</Bucket>
+          <KeyMarker></KeyMarker>
+          <UploadIdMarker></UploadIdMarker>
+          <NextKeyMarker></NextKeyMarker>
+          <NextUploadIdMarker></NextUploadIdMarker>
+          <Delimiter></Delimiter>
+          <Prefix></Prefix>
+          <MaxUploads>1000</MaxUploads>
+          <IsTruncated>false</IsTruncated>
+        </ListMultipartUploadsResult>''']
+
+        do_request.auto_spec = True
+        do_request.side_effect = make_do4body(body_list=body_list)
+
+        got = list(oss2.MultipartUploadIterator(bucket(), max_uploads=1000))
+        self.assertEqual(len(got), 0)
+
+
+
+

--- a/unittests/test_iterator.py
+++ b/unittests/test_iterator.py
@@ -1,0 +1,158 @@
+# -*- coding: utf-8 -*-
+
+from mock import patch
+from common import *
+
+from oss2.models import SimplifiedBucketInfo
+
+
+class TestIterator(OssTestCase):
+    def assertBucketEqual(self, a, b):
+        self.assertEqual(a.name, b.name)
+        self.assertEqual(a.location, b.location)
+        self.assertEqual(a.creation_date, b.creation_date)
+
+    @patch('oss2.Session.do_request')
+    def test_bucket_iterator_not_truncated(self, do_request):
+        body_list = [b'''<?xml version="1.0" encoding="UTF-8"?>
+        <ListAllMyBucketsResult>
+          <Owner>
+            <ID>1047205513514293</ID>
+            <DisplayName>1047205513514293</DisplayName>
+          </Owner>
+          <Buckets>
+            <Bucket>
+              <CreationDate>2015-12-12T00:35:31.000Z</CreationDate>
+              <Location>oss-cn-hangzhou</Location>
+              <Name>bucket-1</Name>
+            </Bucket>
+            <Bucket>
+              <CreationDate>2015-12-11T09:01:57.000Z</CreationDate>
+              <Location>oss-us-west-1</Location>
+              <Name>bucket-2</Name>
+            </Bucket>
+          </Buckets>
+        </ListAllMyBucketsResult>
+        ''']
+
+        req_info = RequestInfo()
+
+        do_request.auto_spec = True
+        do_request.side_effect = make_do4body(req_infos=[req_info], body_list=body_list)
+
+        expected = [SimplifiedBucketInfo('bucket-1', 'oss-cn-hangzhou', 1449880531),
+                    SimplifiedBucketInfo('bucket-2', 'oss-us-west-1', 1449824517)]
+
+        got = list(oss2.BucketIterator(service()))
+
+        self.assertEqual(len(expected), len(got))
+        self.assertBucketEqual(expected[0], got[0])
+        self.assertBucketEqual(expected[1], got[1])
+
+        self.assertEqual(req_info.req.params.get('prefix', ''), '')
+        self.assertEqual(req_info.req.params.get('marker', ''), '')
+
+    @patch('oss2.Session.do_request')
+    def test_bucket_iterator_truncated(self, do_request):
+        body_list = [b'''<?xml version="1.0" encoding="UTF-8"?>
+        <ListAllMyBucketsResult>
+          <Owner>
+            <ID>1047205513514293</ID>
+            <DisplayName>1047205513514293</DisplayName>
+          </Owner>
+          <Buckets>
+            <Bucket>
+              <CreationDate>2015-12-23T07:08:55.000Z</CreationDate>
+              <ExtranetEndpoint>oss-cn-beijing.aliyuncs.com</ExtranetEndpoint>
+              <IntranetEndpoint>oss-cn-beijing-internal.aliyuncs.com</IntranetEndpoint>
+              <Location>oss-cn-beijing</Location>
+              <Name>ming-bj</Name>
+            </Bucket>
+            <Bucket>
+              <CreationDate>2014-09-06T13:20:33.000Z</CreationDate>
+              <ExtranetEndpoint>oss-cn-hangzhou.aliyuncs.com</ExtranetEndpoint>
+              <IntranetEndpoint>oss-cn-hangzhou-internal.aliyuncs.com</IntranetEndpoint>
+              <Location>oss-cn-hangzhou</Location>
+              <Name>ming-oss-share</Name>
+            </Bucket>
+          </Buckets>
+          <Prefix></Prefix>
+          <Marker></Marker>
+          <MaxKeys>1</MaxKeys>
+          <IsTruncated>true</IsTruncated>
+          <NextMarker>ming-oss-share</NextMarker>
+        </ListAllMyBucketsResult>''',
+
+        b'''<?xml version="1.0" encoding="UTF-8"?>
+        <ListAllMyBucketsResult>
+          <Owner>
+            <ID>1047205513514293</ID>
+            <DisplayName>1047205513514293</DisplayName>
+          </Owner>
+          <Buckets>
+            <Bucket>
+              <CreationDate>2015-12-25T04:22:43.000Z</CreationDate>
+              <ExtranetEndpoint>oss-cn-qingdao.aliyuncs.com</ExtranetEndpoint>
+              <IntranetEndpoint>oss-cn-qingdao-internal.aliyuncs.com</IntranetEndpoint>
+              <Location>oss-cn-qingdao</Location>
+              <Name>ming-qd</Name>
+            </Bucket>
+            <Bucket>
+              <CreationDate>2015-06-29T13:43:52.000Z</CreationDate>
+              <ExtranetEndpoint>oss-cn-hangzhou.aliyuncs.com</ExtranetEndpoint>
+              <IntranetEndpoint>oss-cn-hangzhou-internal.aliyuncs.com</IntranetEndpoint>
+              <Location>oss-cn-hangzhou</Location>
+              <Name>ming-spike</Name>
+            </Bucket>
+          </Buckets>
+          <Prefix></Prefix>
+          <Marker>ming-oss-share</Marker>
+          <MaxKeys>2</MaxKeys>
+          <IsTruncated>true</IsTruncated>
+          <NextMarker>ming-spike</NextMarker>
+        </ListAllMyBucketsResult>''',
+
+        b'''<?xml version="1.0" encoding="UTF-8"?>
+        <ListAllMyBucketsResult>
+          <Owner>
+            <ID>1047205513514293</ID>
+            <DisplayName>1047205513514293</DisplayName>
+          </Owner>
+          <Buckets>
+            <Bucket>
+              <CreationDate>2015-12-15T13:52:50.000Z</CreationDate>
+              <ExtranetEndpoint>oss-cn-hangzhou.aliyuncs.com</ExtranetEndpoint>
+              <IntranetEndpoint>oss-cn-hangzhou-internal.aliyuncs.com</IntranetEndpoint>
+              <Location>oss-cn-hangzhou</Location>
+              <Name>zzy-share</Name>
+            </Bucket>
+          </Buckets>
+        </ListAllMyBucketsResult>''']
+
+        expected = [SimplifiedBucketInfo('ming-bj', 'oss-cn-beijing', 1450854535),
+                    SimplifiedBucketInfo('ming-oss-share', 'oss-cn-hangzhou', 1410009633),
+                    SimplifiedBucketInfo('ming-qd', 'oss-cn-qingdao', 1451017363),
+                    SimplifiedBucketInfo('ming-spike', 'oss-cn-hangzhou', 1435585432),
+                    SimplifiedBucketInfo('zzy-share', 'oss-cn-hangzhou',1450187570)]
+
+        nreq = 3
+
+        req_infos = [RequestInfo() for i in range(nreq)]
+
+        do_request.auto_spec = True
+        do_request.side_effect = make_do4body(req_infos=req_infos, body_list=body_list)
+
+        got = list(oss2.BucketIterator(service(), max_keys=2))
+
+        self.assertEqual(len(expected), len(got))
+
+        for i in range(len(got)):
+            self.assertBucketEqual(expected[i], got[i])
+
+        for i in range(nreq):
+            self.assertEqual(req_infos[i].req.params.get('max-keys'), '2')
+            self.assertEqual(req_infos[i].req.params.get('prefix', ''), '')
+
+        self.assertEqual(req_infos[0].req.params.get('marker', ''), '')
+        self.assertEqual(req_infos[1].req.params.get('marker', ''), 'ming-oss-share')
+        self.assertEqual(req_infos[2].req.params.get('marker', ''), 'ming-spike')

--- a/unittests/test_multipart.py
+++ b/unittests/test_multipart.py
@@ -13,7 +13,7 @@ UPLOAD_ID = '97BD544A65DB46F9A8735C93917A960F'
 class TestMultipart(OssTestCase):
     @patch('oss2.Session.do_request')
     def test_init(self, do_request):
-        body = b'''<?xml version="1.0" encoding="UTF-8"?>
+        body = '''<?xml version="1.0" encoding="UTF-8"?>
         <InitiateMultipartUploadResult>
           <Bucket>ming-oss-share</Bucket>
           <Key>uosvelpvgjwtxaciqtxoplnx</Key>
@@ -49,7 +49,7 @@ class TestMultipart(OssTestCase):
         parts.append(PartInfo(2, '9433E6178C51CFEC867F592F4B827B50'))
         parts.append(PartInfo(3, '5570B91F31EBB06B6BA93BA6D63BE68A'))
 
-        body = b'''<?xml version="1.0" encoding="UTF-8"?>
+        body = '''<?xml version="1.0" encoding="UTF-8"?>
         <CompleteMultipartUploadResult>
           <Location>http://ming-oss-share.oss-cn-hangzhou.aliyuncs.com/fake-key</Location>
           <Bucket>ming-oss-share</Bucket>


### PR DESCRIPTION
缺省参数，如request_retries，connect_timeout，需要可以通过设置defaults里的值进行动态调整。
以前的代码错在用default argument来初始化这些参数，而default arguments的值是在 def 被evaluate的时候确定的。现在改为在函数体内初始化。

为了兼容2.4.0以前的requests库，我们只用connect timeout一个参数来设置timeout，而不是用(connect_timeout, read_timeout)这样的tuple来设置。所以read timeout和connect timeout的值是一样的。对于CopyObject、UploadPartCopy来说，很可能会超过原先的connect timeout值（10秒）读不到数据。

另外还增加了UT。