### PR TITLE
delete object also need customized headers if user sign this request with STS token

### DIFF
--- a/oss2/api.py
+++ b/oss2/api.py
@@ -504,14 +504,14 @@ class Bucket(_Base):
         """
         return self.copy_object(self.bucket_name, key, key, headers=headers)
 
-    def delete_object(self, key):
+    def delete_object(self, key, headers=None):
         """删除一个文件。
 
         :param str key: 文件名
 
         :return: :class:`RequestResult <oss2.models.RequestResult>`
         """
-        resp = self.__do_object('DELETE', key)
+        resp = self.__do_object('DELETE', key, headers=headers)
         return RequestResult(resp)
 
     def put_object_acl(self, key, permission):


### PR DESCRIPTION
I tried to delete an OSS object via the official SDK but the delete_object API doesn't allow me to set headers. However if I sign this request using STS granted temporary token, I have to set x-oss-security-token in HTTP header manually. The current API didn't expose this parameter to me.