### PR TITLE
crc

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ python:
 - 3.4
 - 3.5
 install:
-- pip install requests nose nose-cov python-coveralls aliyun-python-sdk-sts
+- pip install crcmod requests nose nose-cov python-coveralls aliyun-python-sdk-sts
 - pip install --upgrade mock
 script:
 - nosetests unittests/ --with-cov

--- a/oss2/api.py
+++ b/oss2/api.py
@@ -348,7 +348,7 @@ class Bucket(_Base):
         result = PutObjectResult(resp)
         
         if self.enable_crc:
-            utils.check_crc('put', data.get_crc(), result.crc)
+            utils.check_crc('put', data.crc, result.crc)
             
         return result
 
@@ -411,7 +411,7 @@ class Bucket(_Base):
         result =  AppendObjectResult(resp)
     
         if self.enable_crc and init_crc is not None:
-            utils.check_crc('append', data.get_crc(), result.crc)
+            utils.check_crc('append', data.crc, result.crc)
             
         return result
 
@@ -644,7 +644,7 @@ class Bucket(_Base):
         result = PutObjectResult(resp)
     
         if self.enable_crc:
-            utils.check_crc('put', data.get_crc(), result.crc)
+            utils.check_crc('put', data.crc, result.crc)
         
         return result
 

--- a/oss2/api.py
+++ b/oss2/api.py
@@ -375,7 +375,7 @@ class Bucket(_Base):
     def append_object(self, key, position, data,
                       headers=None,
                       progress_callback=None,
-                      initCrc=None):
+                      init_crc=None):
         """追加上传一个文件。
 
         :param str key: 新的文件名，或已经存在的可追加文件名
@@ -401,8 +401,8 @@ class Bucket(_Base):
         if progress_callback:
             data = utils.make_progress_adapter(data, progress_callback)
         
-        if self.enable_crc and initCrc is not None:
-            data = utils.make_crc_adapter(data, initCrc)
+        if self.enable_crc and init_crc is not None:
+            data = utils.make_crc_adapter(data, init_crc)
 
         resp = self.__do_object('POST', key,
                                 data=data,
@@ -410,7 +410,7 @@ class Bucket(_Base):
                                 params={'append': '', 'position': str(position)})
         result =  AppendObjectResult(resp)
     
-        if self.enable_crc and initCrc is not None:
+        if self.enable_crc and init_crc is not None:
             utils.check_crc('append', data.get_crc(), result.crc)
             
         return result

--- a/oss2/api.py
+++ b/oss2/api.py
@@ -127,12 +127,13 @@ import oss2.utils
 
 class _Base(object):
     def __init__(self, auth, endpoint, is_cname, session, connect_timeout,
-                 app_name=''):
+                 app_name='', enable_crc=True):
         self.auth = auth
         self.endpoint = _normalize_endpoint(endpoint.strip())
         self.session = session or http.Session()
         self.timeout = defaults.get(connect_timeout, defaults.connect_timeout)
         self.app_name = app_name
+        self.enable_crc = enable_crc
 
         self._make_url = _UrlMaker(self.endpoint, is_cname)
 
@@ -245,9 +246,11 @@ class Bucket(_Base):
                  is_cname=False,
                  session=None,
                  connect_timeout=None,
-                 app_name=''):
+                 app_name='',
+                 enable_crc=True):
         super(Bucket, self).__init__(auth, endpoint, is_cname, session, connect_timeout,
-                                     app_name=app_name)
+                                     app_name, enable_crc)
+                
         self.bucket_name = bucket_name.strip()
 
     def sign_url(self, method, key, expires, headers=None, params=None):
@@ -337,9 +340,17 @@ class Bucket(_Base):
 
         if progress_callback:
             data = utils.make_progress_adapter(data, progress_callback)
+        
+        if self.enable_crc:
+            data = utils.make_crc_adapter(data)
 
         resp = self.__do_object('PUT', key, data=data, headers=headers)
-        return PutObjectResult(resp)
+        result = PutObjectResult(resp)
+        
+        if self.enable_crc:
+            utils.check_crc('put', data.get_crc(), result.crc)
+            
+        return result
 
     def put_object_from_file(self, key, filename,
                              headers=None,
@@ -363,7 +374,8 @@ class Bucket(_Base):
 
     def append_object(self, key, position, data,
                       headers=None,
-                      progress_callback=None):
+                      progress_callback=None,
+                      initCrc=None):
         """追加上传一个文件。
 
         :param str key: 新的文件名，或已经存在的可追加文件名
@@ -388,12 +400,20 @@ class Bucket(_Base):
 
         if progress_callback:
             data = utils.make_progress_adapter(data, progress_callback)
+        
+        if self.enable_crc and initCrc is not None:
+            data = utils.make_crc_adapter(data, initCrc)
 
         resp = self.__do_object('POST', key,
                                 data=data,
                                 headers=headers,
                                 params={'append': '', 'position': str(position)})
-        return AppendObjectResult(resp)
+        result =  AppendObjectResult(resp)
+    
+        if self.enable_crc and initCrc is not None:
+            utils.check_crc('append', data.get_crc(), result.crc)
+            
+        return result
 
     def get_object(self, key,
                    byte_range=None,
@@ -433,7 +453,7 @@ class Bucket(_Base):
             params={'x-oss-process': process}
         
         resp = self.__do_object('GET', key, headers=headers, params=params)
-        return GetObjectResult(resp, progress_callback=progress_callback)
+        return GetObjectResult(resp, progress_callback, self.enable_crc)
 
     def get_object_to_file(self, key, filename,
                            byte_range=None,
@@ -614,11 +634,19 @@ class Bucket(_Base):
         """
         if progress_callback:
             data = utils.make_progress_adapter(data, progress_callback)
+        
+        if self.enable_crc:
+            data = utils.make_crc_adapter(data)
 
         resp = self.__do_object('PUT', key,
                                 params={'uploadId': upload_id, 'partNumber': str(part_number)},
                                 data=data)
-        return PutObjectResult(resp)
+        result = PutObjectResult(resp)
+    
+        if self.enable_crc:
+            utils.check_crc('put', data.get_crc(), result.crc)
+        
+        return result
 
     def complete_multipart_upload(self, key, upload_id, parts, headers=None):
         """完成分片上传，创建文件。

--- a/oss2/exceptions.py
+++ b/oss2/exceptions.py
@@ -21,7 +21,7 @@ _OSS_ERROR_TO_EXCEPTION = {} # populated at end of module
 
 OSS_CLIENT_ERROR_STATUS = -1
 OSS_REQUEST_ERROR_STATUS = -2
-OSS_CRC_ERROR_STATUS = -3
+OSS_INCONSISTENT_ERROR_STATUS = -3
 
 class OssError(Exception):
     def __init__(self, status, headers, body, details):
@@ -70,9 +70,9 @@ class RequestError(OssError):
         return str(error)
 
 
-class CrcError(OssError):
+class InconsistentError(OssError):
     def __init__(self, message):
-        OssError.__init__(self, OSS_CRC_ERROR_STATUS, {}, 'CrcError: ' + message, {})
+        OssError.__init__(self, OSS_INCONSISTENT_ERROR_STATUS, {}, 'InconsistentError: ' + message, {})
 
     def __str__(self):
         error = {'status': self.status,

--- a/oss2/exceptions.py
+++ b/oss2/exceptions.py
@@ -21,7 +21,7 @@ _OSS_ERROR_TO_EXCEPTION = {} # populated at end of module
 
 OSS_CLIENT_ERROR_STATUS = -1
 OSS_REQUEST_ERROR_STATUS = -2
-
+OSS_CRC_ERROR_STATUS = -3
 
 class OssError(Exception):
     def __init__(self, status, headers, body, details):
@@ -63,6 +63,16 @@ class RequestError(OssError):
     def __init__(self, e):
         OssError.__init__(self, OSS_REQUEST_ERROR_STATUS, {}, 'RequestError: ' + str(e), {})
         self.exception = e
+
+    def __str__(self):
+        error = {'status': self.status,
+                 'details': self.body}
+        return str(error)
+
+
+class CrcError(OssError):
+    def __init__(self, message):
+        OssError.__init__(self, OSS_CRC_ERROR_STATUS, {}, 'CrcError: ' + message, {})
 
     def __str__(self):
         error = {'status': self.status,

--- a/oss2/models.py
+++ b/oss2/models.py
@@ -7,7 +7,7 @@ oss2.models
 该模块包含Python SDK API接口所需要的输入参数以及返回值类型。
 """
 
-from .utils import http_to_unixtime, make_progress_adapter, http_date
+from .utils import http_to_unixtime, make_progress_adapter, make_crc_adapter
 from .exceptions import ClientError
 
 
@@ -77,19 +77,33 @@ class HeadObjectResult(RequestResult):
 
 
 class GetObjectResult(HeadObjectResult):
-    def __init__(self, resp, progress_callback=None):
+    def __init__(self, resp, progress_callback=None, crc_callback=None):
         super(GetObjectResult, self).__init__(resp)
-
+        self.crc_callback = crc_callback
+        
         if progress_callback:
             self.stream = make_progress_adapter(self.resp, progress_callback, self.content_length)
         else:
             self.stream = self.resp
-
+        
+        self.crc = _hget(self.headers, 'x-oss-hash-crc64ecma', int)
+        if self.crc_callback:
+            self.stream = make_crc_adapter(self.stream)
+            
     def read(self, amt=None):
         return self.stream.read(amt)
 
     def __iter__(self):
         return iter(self.stream)
+    
+    def get_client_crc(self):
+        if self.crc_callback:
+            return self.stream.get_crc()
+        else:
+            return None
+    
+    def get_oss_crc(self):
+        return self.crc
 
 
 class PutObjectResult(RequestResult):
@@ -98,6 +112,9 @@ class PutObjectResult(RequestResult):
 
         #: HTTP ETag
         self.etag = _get_etag(self.headers)
+        
+        #: 文件上传后，OSS上文件的CRC64值
+        self.crc = _hget(resp.headers, 'x-oss-hash-crc64ecma', int)
 
 
 class AppendObjectResult(RequestResult):

--- a/oss2/models.py
+++ b/oss2/models.py
@@ -104,7 +104,7 @@ class GetObjectResult(HeadObjectResult):
             return None
     
     @property
-    def oss_crc(self):
+    def server_crc(self):
         return self.__crc
 
 

--- a/oss2/utils.py
+++ b/oss2/utils.py
@@ -19,9 +19,10 @@ import calendar
 import datetime
 import time
 import errno
+import crcmod
 
 from .compat import to_string, to_bytes
-from .exceptions import ClientError
+from .exceptions import ClientError, CrcError
 
 
 _EXTRA_TYPES_MAP = {
@@ -181,20 +182,56 @@ def make_progress_adapter(data, progress_callback, size=None):
 
     if size is None:
         if hasattr(data, 'read'):
-            return _ProgressFileAdapter(data, progress_callback)
+            return _FileLikeAdapter(data, progress_callback)
         elif hasattr(data, '__iter__'):
-            return _ProgressIterableAdapter(data, progress_callback)
+            return _IterableAdapter(data, progress_callback)
         else:
             raise ClientError('{0} is not a file object, nor an iterator'.format(data.__class__.__name__))
     else:
-        return _SizedProgressFileAdapter(data, progress_callback, size)
+        return _BytesAndFileAdapter(data, progress_callback, size)
 
 
-class _ProgressIterableAdapter(object):
-    def __init__(self, data, progress_callback):
+def make_crc_adapter(data, initCrc=0L):
+    """返回一个适配器，从而在读取 `data` ，即调用read或者对其进行迭代的时候，能够计算CRC。
+
+    :param data: 可以是bytes、file object或iterable
+    :param initCrc: 初始CRC值，可选
+
+    :return: 能够调用计算CRC函数的适配器
+    """
+    data = to_bytes(data)
+
+    # bytes or file object
+    if hasattr(data, '__len__') or (hasattr(data, 'seek') and hasattr(data, 'tell')):
+        return _BytesAndFileAdapter(data, 
+                                    size=_get_data_size(data), 
+                                    crc_callback=crc_callback, 
+                                    initCrc=initCrc)
+    # file-like object
+    elif hasattr(data, 'read'): 
+        return _FileLikeAdapter(data, crc_callback=crc_callback, initCrc=initCrc)
+    # iterator
+    elif hasattr(data, '__iter__'):
+        return _IterableAdapter(data, crc_callback=crc_callback, initCrc=initCrc)
+    else:
+        raise ClientError('{0} is not a file object, nor an iterator'.format(data.__class__.__name__))
+
+def crc_callback(crc, data):
+    crc.update(data)
+    
+def check_crc(operation, client_crc, oss_crc):
+    if client_crc != oss_crc:
+        raise CrcError('the crc of {0} between client and oss is not inconsistent'.format(operation))
+
+class _IterableAdapter(object):
+    def __init__(self, data, progress_callback=None, crc_callback=None, initCrc=0L):
         self.iter = iter(data)
         self.progress_callback = progress_callback
         self.offset = 0
+        
+        self.crc_callback = crc_callback
+        if crc_callback:
+            self.crc = Crc64(initCrc)
 
     def __iter__(self):
         return self
@@ -203,24 +240,34 @@ class _ProgressIterableAdapter(object):
         return self.next()
 
     def next(self):
-        self.progress_callback(self.offset, None)
+        if self.progress_callback:
+            self.progress_callback(self.offset, None)
 
         content = next(self.iter)
         self.offset += len(content)
+        
+        if self.crc_callback:
+            self.crc_callback(self.crc, content)
 
         return content
+    
+    def get_crc(self):
+        return self.crc.get_crc_value()
 
-
-class _ProgressFileAdapter(object):
+class _FileLikeAdapter(object):
     """通过这个适配器，可以给无法确定内容长度的 `fileobj` 加上进度监控。
 
     :param fileobj: file-like object，只要支持read即可
     :param progress_callback: 进度回调函数
     """
-    def __init__(self, fileobj, progress_callback):
+    def __init__(self, fileobj, progress_callback=None, crc_callback=None, initCrc=0L):
         self.fileobj = fileobj
         self.progress_callback = progress_callback
         self.offset = 0
+        
+        self.crc_callback = crc_callback
+        if crc_callback:
+            self.crc = Crc64(initCrc)
 
     def __iter__(self):
         return self
@@ -239,15 +286,23 @@ class _ProgressFileAdapter(object):
     def read(self, amt=None):
         content = self.fileobj.read(amt)
         if not content:
-            self.progress_callback(self.offset, None)
+            if self.progress_callback:
+                self.progress_callback(self.offset, None)
         else:
-            self.progress_callback(self.offset, None)
+            if self.progress_callback:
+                self.progress_callback(self.offset, None)
+                
             self.offset += len(content)
+            
+            if self.crc_callback:
+                self.crc_callback(self.crc, content)
 
         return content
-
-
-class _SizedProgressFileAdapter(object):
+    
+    def get_crc(self):
+        return self.crc.get_crc_value()
+    
+class _BytesAndFileAdapter(object):
     """通过这个适配器，可以给 `data` 加上进度监控。
 
     :param data: 可以是unicode字符串（内部会转换为UTF-8编码的bytes）、bytes或file object
@@ -255,15 +310,24 @@ class _SizedProgressFileAdapter(object):
         其中bytes_read是已经读取的字节数；total_bytes是总的字节数。
     :param int size: `data` 包含的字节数。
     """
-    def __init__(self, data, progress_callback, size):
+    def __init__(self, data, progress_callback=None, size=None, crc_callback=None, initCrc=0L):
         self.data = to_bytes(data)
         self.progress_callback = progress_callback
         self.size = size
-
         self.offset = 0
+        
+        self.crc_callback = crc_callback
+        if crc_callback:
+            self.crc = Crc64(initCrc)
 
     def __len__(self):
         return self.size
+    
+    # for python 2.x
+    def __bool__(self):
+        return True
+    # for python 3.x
+    __nonzero__=__bool__
 
     def __iter__(self):
         return self
@@ -280,8 +344,6 @@ class _SizedProgressFileAdapter(object):
             raise StopIteration
 
     def read(self, amt=None):
-        self.progress_callback(min(self.offset, self.size), self.size)
-
         if self.offset >= self.size:
             return ''
 
@@ -296,8 +358,31 @@ class _SizedProgressFileAdapter(object):
             content = self.data.read(bytes_to_read)
 
         self.offset += bytes_to_read
+        
+        if self.progress_callback:
+            self.progress_callback(min(self.offset, self.size), self.size)
+        
+        if self.crc_callback:
+            self.crc_callback(self.crc, content)
 
         return content
+    
+    def get_crc(self):
+        return self.crc.get_crc_value()
+
+class Crc64(object):
+
+    _POLY = 0x142F0E1EBA9EA3693L
+    _XOROUT = 0XFFFFFFFFFFFFFFFFL
+    
+    def __init__(self, initCrc=0L):
+        self.crc64 = crcmod.Crc(self._POLY, initCrc=initCrc, rev=True, xorOut=self._XOROUT)
+
+    def update(self, data):
+        self.crc64.update(data)
+    
+    def get_crc_value(self):
+        return self.crc64.crcValue
 
 
 _STRPTIME_LOCK = threading.Lock()

--- a/oss2/utils.py
+++ b/oss2/utils.py
@@ -22,7 +22,7 @@ import errno
 import crcmod
 
 from .compat import to_string, to_bytes
-from .exceptions import ClientError, CrcError
+from .exceptions import ClientError, InconsistentError
 
 
 _EXTRA_TYPES_MAP = {
@@ -221,7 +221,7 @@ def _crc_callback(crc, data):
     
 def check_crc(operation, client_crc, oss_crc):
     if client_crc != oss_crc:
-        raise CrcError('the crc of {0} between client and oss is not inconsistent'.format(operation))
+        raise InconsistentError('the crc of {0} between client and oss is not inconsistent'.format(operation))
 
 def _invoke_crc_updater(crc_callback, __crc_calculator, content):
     if crc_callback:

--- a/oss2/utils.py
+++ b/oss2/utils.py
@@ -372,8 +372,8 @@ class _BytesAndFileAdapter(object):
 
 class Crc64(object):
 
-    _POLY = 0x142F0E1EBA9EA3693L
-    _XOROUT = 0XFFFFFFFFFFFFFFFFL
+    _POLY = 0x142F0E1EBA9EA3693
+    _XOROUT = 0XFFFFFFFFFFFFFFFF
     
     def __init__(self, init_crc=0):
         self.crc64 = crcmod.Crc(self._POLY, initCrc=init_crc, rev=True, xorOut=self._XOROUT)

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,8 @@ setup(
     description='Aliyun OSS (Object Storage Service) SDK',
     long_description=readme,
     packages=['oss2'],
-    install_requires=['requests!=2.9.0'],
+    install_requires=['requests!=2.9.0',
+                      'crcmod>=1.7'],
     include_package_data=True,
     url='http://oss.aliyun.com',
     classifiers=[

--- a/tests/test_bucket.py
+++ b/tests/test_bucket.py
@@ -79,6 +79,7 @@ class TestBucket(OssTestCase):
 
         # 设置index页面和error页面
         self.bucket.put_bucket_website(oss2.models.BucketWebsite('index.html', 'error.html'))
+        time.sleep(5)
 
         def same_website(website, index, error):
             return website.index_file == index and website.error_file == error

--- a/tests/test_mock_object.py
+++ b/tests/test_mock_object.py
@@ -56,7 +56,8 @@ Date: Sat, 12 Dec 2015 00:35:53 GMT
 Content-Length: 0
 Connection: keep-alive
 x-oss-request-id: 566B6BE93A7B8CFD53D4BAA3
-ETag: "D80CF0E5BE2436514894D64B2BCFB2AE"'''
+x-oss-hash-crc64ecma: {0}
+ETag: "D80CF0E5BE2436514894D64B2BCFB2AE"'''.format(unittests.common.calc_crc(content))
 
     return request_text, response_text
 
@@ -82,7 +83,7 @@ Connection: keep-alive
 x-oss-request-id: 566B6C0D1790CF586F72240B
 ETag: "24F7FA10676D816E0D6C6B5600000000"
 x-oss-next-append-position: {0}
-x-oss-hash-crc64ecma: 7962765905601689380'''.format(position + len(content))
+x-oss-hash-crc64ecma: {1}'''.format(position + len(content), unittests.common.calc_crc(content))
 
     return request_text, response_text
 
@@ -334,7 +335,7 @@ x-oss-request-id: 566B6C3D6086505A0CFF0F68
         self.assertEqual(result.status, 200)
         self.assertEqual(result.next_position, size)
         self.assertEqual(result.etag, '24F7FA10676D816E0D6C6B5600000000')
-        self.assertEqual(result.crc, 7962765905601689380)
+        self.assertEqual(result.crc, unittests.common.calc_crc(content))
 
     @patch('oss2.Session.do_request')
     def test_append_with_progress(self, do_request):

--- a/tests/test_multipart.py
+++ b/tests/test_multipart.py
@@ -16,6 +16,7 @@ class TestMultipart(OssTestCase):
 
         result = self.bucket.upload_part(key, upload_id, 1, content)
         parts.append(oss2.models.PartInfo(1, result.etag))
+        self.assertIsNotNone(result.crc)
 
         self.bucket.complete_multipart_upload(key, upload_id, parts)
 

--- a/tests/test_multipart.py
+++ b/tests/test_multipart.py
@@ -16,7 +16,7 @@ class TestMultipart(OssTestCase):
 
         result = self.bucket.upload_part(key, upload_id, 1, content)
         parts.append(oss2.models.PartInfo(1, result.etag))
-        self.assertIsNotNone(result.crc)
+        self.assertTrue(result.crc is not None)
 
         self.bucket.complete_multipart_upload(key, upload_id, parts)
 

--- a/tests/test_object.py
+++ b/tests/test_object.py
@@ -38,8 +38,8 @@ class TestObject(OssTestCase):
         get_result = self.bucket.get_object(key)
         self.assertEqual(get_result.read(), content)
         assert_result(get_result)
-        self.assertIsNotNone(get_result.get_client_crc())
-        self.assertIsNotNone(get_result.get_oss_crc())
+        self.assertTrue(get_result.get_client_crc() is not None)
+        self.assertTrue(get_result.get_oss_crc() is not None)
         self.assertTrue(get_result.get_client_crc() == get_result.get_oss_crc())
 
         head_result = self.bucket.head_object(key)
@@ -102,9 +102,9 @@ class TestObject(OssTestCase):
         src = self.bucket.get_object(src_key)
         result = self.bucket.put_object(dst_key, src)
 
-        # verify
-        self.assertIsNotNone(src.get_client_crc())
-        self.assertIsNotNone(src.get_client_crc())
+        # verify        
+        self.assertTrue(src.get_client_crc() is not None)
+        self.assertTrue(src.get_oss_crc() is not None)  
         self.assertEqual(src.get_client_crc(), src.get_oss_crc())
         self.assertEqual(result.crc, src.get_oss_crc())
         self.assertEqual(self.bucket.get_object(src_key).read(), self.bucket.get_object(dst_key).read())
@@ -254,9 +254,9 @@ class TestObject(OssTestCase):
         content1 = random_bytes(512)
         content2 = random_bytes(128)
 
-        result = self.bucket.append_object(key, 0, content1, initCrc=0)
+        result = self.bucket.append_object(key, 0, content1, init_crc=0)
         self.assertEqual(result.next_position, len(content1))
-        self.assertIsNotNone(result.crc)
+        self.assertTrue(result.crc is not None)
 
         try:
             self.bucket.append_object(key, 0, content2)
@@ -265,9 +265,9 @@ class TestObject(OssTestCase):
         else:
             self.assertTrue(False)
         
-        result = self.bucket.append_object(key, len(content1), content2, initCrc=result.crc)
+        result = self.bucket.append_object(key, len(content1), content2, init_crc=result.crc)
         self.assertEqual(result.next_position, len(content1) + len(content2))
-        self.assertIsNotNone(result.crc)
+        self.assertTrue(result.crc is not None)
 
         self.bucket.delete_object(key)
 
@@ -437,12 +437,12 @@ class TestObject(OssTestCase):
         # put
         put_result = bucket.put_object(key, content)
         self.assertFalse(hasattr(put_result, 'get_crc'))
-        self.assertIsNotNone(put_result.crc)
+        self.assertTrue(put_result.crc is not None)
         
         # get 
         get_result = bucket.get_object(key)
         self.assertEqual(get_result.read(), content)
-        self.assertIsNone(get_result.get_client_crc())
+        self.assertTrue(get_result.get_client_crc() is None)
         self.assertTrue(get_result.get_oss_crc())
         
         bucket.delete_object(key)
@@ -450,11 +450,11 @@ class TestObject(OssTestCase):
         # append
         append_result = bucket.append_object(key, 0, content)
         self.assertFalse(hasattr(append_result, 'get_crc'))
-        self.assertIsNotNone(append_result.crc)
+        self.assertTrue(append_result.crc is not None)
         
         append_result = bucket.append_object(key, len(content), content)
         self.assertFalse(hasattr(append_result, 'get_crc'))
-        self.assertIsNotNone(append_result.crc)
+        self.assertTrue(append_result.crc is not None)
         
         bucket.delete_object(key)
         
@@ -471,10 +471,10 @@ class TestObject(OssTestCase):
 
     def test_invalid_crc(self):
         key = self.random_key()
-        content1 = random_bytes(512)
+        content = random_bytes(512)
 
         try:
-            self.bucket.append_object(key, 0, content1, initCrc=1)
+            self.bucket.append_object(key, 0, content, init_crc=1)
         except oss2.exceptions.CrcError as e:
             self.assertEqual(e.status, -3)
             self.assertTrue(e.body.startswith('CrcError: the crc of'))

--- a/tests/test_object.py
+++ b/tests/test_object.py
@@ -38,9 +38,9 @@ class TestObject(OssTestCase):
         get_result = self.bucket.get_object(key)
         self.assertEqual(get_result.read(), content)
         assert_result(get_result)
-        self.assertTrue(get_result.get_client_crc() is not None)
-        self.assertTrue(get_result.get_oss_crc() is not None)
-        self.assertTrue(get_result.get_client_crc() == get_result.get_oss_crc())
+        self.assertTrue(get_result.client_crc is not None)
+        self.assertTrue(get_result.oss_crc is not None)
+        self.assertTrue(get_result.client_crc == get_result.oss_crc)
 
         head_result = self.bucket.head_object(key)
         assert_result(head_result)
@@ -103,10 +103,10 @@ class TestObject(OssTestCase):
         result = self.bucket.put_object(dst_key, src)
 
         # verify        
-        self.assertTrue(src.get_client_crc() is not None)
-        self.assertTrue(src.get_oss_crc() is not None)  
-        self.assertEqual(src.get_client_crc(), src.get_oss_crc())
-        self.assertEqual(result.crc, src.get_oss_crc())
+        self.assertTrue(src.client_crc is not None)
+        self.assertTrue(src.oss_crc is not None)  
+        self.assertEqual(src.client_crc, src.oss_crc)
+        self.assertEqual(result.crc, src.oss_crc)
         self.assertEqual(self.bucket.get_object(src_key).read(), self.bucket.get_object(dst_key).read())
 
     def make_generator(self, content, chunk_size):
@@ -442,8 +442,8 @@ class TestObject(OssTestCase):
         # get 
         get_result = bucket.get_object(key)
         self.assertEqual(get_result.read(), content)
-        self.assertTrue(get_result.get_client_crc() is None)
-        self.assertTrue(get_result.get_oss_crc())
+        self.assertTrue(get_result.client_crc is None)
+        self.assertTrue(get_result.oss_crc)
         
         bucket.delete_object(key)
         

--- a/tests/test_object.py
+++ b/tests/test_object.py
@@ -475,9 +475,9 @@ class TestObject(OssTestCase):
 
         try:
             self.bucket.append_object(key, 0, content, init_crc=1)
-        except oss2.exceptions.CrcError as e:
+        except oss2.exceptions.InconsistentError as e:
             self.assertEqual(e.status, -3)
-            self.assertTrue(e.body.startswith('CrcError: the crc of'))
+            self.assertTrue(e.body.startswith('InconsistentError: the crc of'))
         else:
             self.assertTrue(False)
 

--- a/tests/test_object.py
+++ b/tests/test_object.py
@@ -39,8 +39,8 @@ class TestObject(OssTestCase):
         self.assertEqual(get_result.read(), content)
         assert_result(get_result)
         self.assertTrue(get_result.client_crc is not None)
-        self.assertTrue(get_result.oss_crc is not None)
-        self.assertTrue(get_result.client_crc == get_result.oss_crc)
+        self.assertTrue(get_result.server_crc is not None)
+        self.assertTrue(get_result.client_crc == get_result.server_crc)
 
         head_result = self.bucket.head_object(key)
         assert_result(head_result)
@@ -104,9 +104,9 @@ class TestObject(OssTestCase):
 
         # verify        
         self.assertTrue(src.client_crc is not None)
-        self.assertTrue(src.oss_crc is not None)  
-        self.assertEqual(src.client_crc, src.oss_crc)
-        self.assertEqual(result.crc, src.oss_crc)
+        self.assertTrue(src.server_crc is not None)  
+        self.assertEqual(src.client_crc, src.server_crc)
+        self.assertEqual(result.crc, src.server_crc)
         self.assertEqual(self.bucket.get_object(src_key).read(), self.bucket.get_object(dst_key).read())
 
     def make_generator(self, content, chunk_size):
@@ -443,7 +443,7 @@ class TestObject(OssTestCase):
         get_result = bucket.get_object(key)
         self.assertEqual(get_result.read(), content)
         self.assertTrue(get_result.client_crc is None)
-        self.assertTrue(get_result.oss_crc)
+        self.assertTrue(get_result.server_crc)
         
         bucket.delete_object(key)
         

--- a/tests/test_object.py
+++ b/tests/test_object.py
@@ -38,6 +38,9 @@ class TestObject(OssTestCase):
         get_result = self.bucket.get_object(key)
         self.assertEqual(get_result.read(), content)
         assert_result(get_result)
+        self.assertIsNotNone(get_result.get_client_crc())
+        self.assertIsNotNone(get_result.get_oss_crc())
+        self.assertTrue(get_result.get_client_crc() == get_result.get_oss_crc())
 
         head_result = self.bucket.head_object(key)
         assert_result(head_result)
@@ -97,9 +100,13 @@ class TestObject(OssTestCase):
 
         # 获取OSS上的文件，一边读取一边写入到另外一个OSS文件
         src = self.bucket.get_object(src_key)
-        self.bucket.put_object(dst_key, src)
+        result = self.bucket.put_object(dst_key, src)
 
         # verify
+        self.assertIsNotNone(src.get_client_crc())
+        self.assertIsNotNone(src.get_client_crc())
+        self.assertEqual(src.get_client_crc(), src.get_oss_crc())
+        self.assertEqual(result.crc, src.get_oss_crc())
         self.assertEqual(self.bucket.get_object(src_key).read(), self.bucket.get_object(dst_key).read())
 
     def make_generator(self, content, chunk_size):
@@ -247,8 +254,9 @@ class TestObject(OssTestCase):
         content1 = random_bytes(512)
         content2 = random_bytes(128)
 
-        result = self.bucket.append_object(key, 0, content1)
+        result = self.bucket.append_object(key, 0, content1, initCrc=0)
         self.assertEqual(result.next_position, len(content1))
+        self.assertIsNotNone(result.crc)
 
         try:
             self.bucket.append_object(key, 0, content2)
@@ -256,9 +264,10 @@ class TestObject(OssTestCase):
             self.assertEqual(e.next_position, len(content1))
         else:
             self.assertTrue(False)
-
-        result = self.bucket.append_object(key, len(content1), content2)
+        
+        result = self.bucket.append_object(key, len(content1), content2, initCrc=result.crc)
         self.assertEqual(result.next_position, len(content1) + len(content2))
+        self.assertIsNotNone(result.crc)
 
         self.bucket.delete_object(key)
 
@@ -418,6 +427,59 @@ class TestObject(OssTestCase):
         content = random_bytes(16)
 
         self.assertRaises(oss2.exceptions.InvalidObjectName, self.bucket.put_object, key, content)
+
+    def test_disable_crc(self): 
+        key = self.random_key('.txt')
+        content = random_bytes(1024 * 100)
+        
+        bucket = oss2.Bucket(oss2.Auth(OSS_ID, OSS_SECRET), OSS_ENDPOINT, OSS_BUCKET, enable_crc=False)
+        
+        # put
+        put_result = bucket.put_object(key, content)
+        self.assertFalse(hasattr(put_result, 'get_crc'))
+        self.assertIsNotNone(put_result.crc)
+        
+        # get 
+        get_result = bucket.get_object(key)
+        self.assertEqual(get_result.read(), content)
+        self.assertIsNone(get_result.get_client_crc())
+        self.assertTrue(get_result.get_oss_crc())
+        
+        bucket.delete_object(key)
+        
+        # append
+        append_result = bucket.append_object(key, 0, content)
+        self.assertFalse(hasattr(append_result, 'get_crc'))
+        self.assertIsNotNone(append_result.crc)
+        
+        append_result = bucket.append_object(key, len(content), content)
+        self.assertFalse(hasattr(append_result, 'get_crc'))
+        self.assertIsNotNone(append_result.crc)
+        
+        bucket.delete_object(key)
+        
+        # multipart
+        upload_id = bucket.init_multipart_upload(key).upload_id
+
+        parts = []
+        result = bucket.upload_part(key, upload_id, 1, content)
+        parts.append(oss2.models.PartInfo(1, result.etag))
+        result = bucket.upload_part(key, upload_id, 2, content)
+        parts.append(oss2.models.PartInfo(2, result.etag))
+
+        bucket.complete_multipart_upload(key, upload_id, parts)
+
+    def test_invalid_crc(self):
+        key = self.random_key()
+        content1 = random_bytes(512)
+
+        try:
+            self.bucket.append_object(key, 0, content1, initCrc=1)
+        except oss2.exceptions.CrcError as e:
+            self.assertEqual(e.status, -3)
+            self.assertTrue(e.body.startswith('CrcError: the crc of'))
+        else:
+            self.assertTrue(False)
 
 
 if __name__ == '__main__':

--- a/unittests/common.py
+++ b/unittests/common.py
@@ -273,6 +273,11 @@ def get_length(data):
     except TypeError:
         return None
 
+def calc_crc(data):
+    crc = oss2.utils.Crc64()
+    crc.update(data)
+    return crc.get_crc_value()
+
 
 class MockSocket(object):
     def __init__(self, payload):

--- a/unittests/common.py
+++ b/unittests/common.py
@@ -276,7 +276,7 @@ def get_length(data):
 def calc_crc(data):
     crc = oss2.utils.Crc64()
     crc.update(data)
-    return crc.get_crc_value()
+    return crc.crc_value()
 
 
 class MockSocket(object):

--- a/unittests/common.py
+++ b/unittests/common.py
@@ -276,7 +276,7 @@ def get_length(data):
 def calc_crc(data):
     crc = oss2.utils.Crc64()
     crc.update(data)
-    return crc.crc_value()
+    return crc.crc
 
 
 class MockSocket(object):

--- a/unittests/test_multipart.py
+++ b/unittests/test_multipart.py
@@ -65,7 +65,8 @@ Date: Sat, 12 Dec 2015 00:35:59 GMT
 Content-Length: 0
 Connection: keep-alive
 x-oss-request-id: 566B6BEF6078C0E44874A4AD
-ETag: "DF1F9DE8F39BDE03716AC8D425589A5A"'''
+x-oss-hash-crc64ecma: {0}
+ETag: "DF1F9DE8F39BDE03716AC8D425589A5A"'''.format(calc_crc(content))
 
         req_info = mock_response(do_request, response_text)
         result = bucket().upload_part('tmmzgvvmsgesihfo', '41337E94168A4E6F918C3D6CAAFADCCD', 3, content)

--- a/unittests/test_object.py
+++ b/unittests/test_object.py
@@ -330,7 +330,7 @@ x-oss-request-id: 566B6C3D6086505A0CFF0F68
         request_text, response_text = make_append_object(0, content)
         req_info = mock_response(do_request, response_text)
 
-        result = bucket().append_object('sjbhlsgsbecvlpbf', 0, content, initCrc=0)
+        result = bucket().append_object('sjbhlsgsbecvlpbf', 0, content, init_crc=0)
 
         self.assertRequest(req_info, request_text)
         self.assertEqual(result.status, 200)
@@ -366,7 +366,7 @@ x-oss-request-id: 566B6C3D6086505A0CFF0F68
 
         result = bucket().append_object('sjbhlsgsbecvlpbf', 0, content, 
                                         progress_callback=self.progress_callback,
-                                        initCrc=0)
+                                        init_crc=0)
 
         self.assertRequest(req_info, request_text)
         self.assertEqual(self.previous, size)

--- a/unittests/test_object.py
+++ b/unittests/test_object.py
@@ -57,7 +57,8 @@ Date: Sat, 12 Dec 2015 00:35:53 GMT
 Content-Length: 0
 Connection: keep-alive
 x-oss-request-id: 566B6BE93A7B8CFD53D4BAA3
-ETag: "D80CF0E5BE2436514894D64B2BCFB2AE"'''
+x-oss-hash-crc64ecma: {0}
+ETag: "D80CF0E5BE2436514894D64B2BCFB2AE"'''.format(calc_crc(content))
 
     return request_text, response_text
 
@@ -83,7 +84,7 @@ Connection: keep-alive
 x-oss-request-id: 566B6C0D1790CF586F72240B
 ETag: "24F7FA10676D816E0D6C6B5600000000"
 x-oss-next-append-position: {0}
-x-oss-hash-crc64ecma: 7962765905601689380'''.format(position + len(content))
+x-oss-hash-crc64ecma: {1}'''.format(position + len(content), calc_crc(content))
 
     return request_text, response_text
 
@@ -329,13 +330,29 @@ x-oss-request-id: 566B6C3D6086505A0CFF0F68
         request_text, response_text = make_append_object(0, content)
         req_info = mock_response(do_request, response_text)
 
+        result = bucket().append_object('sjbhlsgsbecvlpbf', 0, content, initCrc=0)
+
+        self.assertRequest(req_info, request_text)
+        self.assertEqual(result.status, 200)
+        self.assertEqual(result.next_position, size)
+        self.assertEqual(result.etag, '24F7FA10676D816E0D6C6B5600000000')
+        self.assertEqual(result.crc, calc_crc(content))
+
+    @patch('oss2.Session.do_request')
+    def test_append_without_crc(self, do_request):
+        size = 8192 * 2 - 1
+        content = random_bytes(size)
+
+        request_text, response_text = make_append_object(0, content)
+        req_info = mock_response(do_request, response_text)
+
         result = bucket().append_object('sjbhlsgsbecvlpbf', 0, content)
 
         self.assertRequest(req_info, request_text)
         self.assertEqual(result.status, 200)
         self.assertEqual(result.next_position, size)
         self.assertEqual(result.etag, '24F7FA10676D816E0D6C6B5600000000')
-        self.assertEqual(result.crc, 7962765905601689380)
+        self.assertEqual(result.crc, calc_crc(content))
 
     @patch('oss2.Session.do_request')
     def test_append_with_progress(self, do_request):
@@ -347,7 +364,9 @@ x-oss-request-id: 566B6C3D6086505A0CFF0F68
 
         self.previous = -1
 
-        result = bucket().append_object('sjbhlsgsbecvlpbf', 0, content, progress_callback=self.progress_callback)
+        result = bucket().append_object('sjbhlsgsbecvlpbf', 0, content, 
+                                        progress_callback=self.progress_callback,
+                                        initCrc=0)
 
         self.assertRequest(req_info, request_text)
         self.assertEqual(self.previous, size)


### PR DESCRIPTION
支持CRC校验。
CRC校验默认开启，用户可以关闭。
CRC开启后，put_object/upload_part自动使用CRC校验；get_object返回服务端的CRC值，客户端数据读取完成后，会返回CRC，比较两个CRC的值，判断数据是否有效；append_object自动使用CRC校验，需要传入上次append的crc值。