### PR TITLE
解决当source_key含中文时copy_object()函数抛出编码异常的问题

### DIFF
--- a/oss2/__init__.py
+++ b/oss2/__init__.py
@@ -1,6 +1,6 @@
 __version__ = '2.2.0'
 
-from . import models, exceptions
+from . import models, exceptions, config
 
 from .api import Service, Bucket
 from .auth import Auth, AnonymousAuth, StsAuth

--- a/oss2/api.py
+++ b/oss2/api.py
@@ -551,7 +551,7 @@ class Bucket(_Base):
         :return: :class:`PutObjectResult <oss2.models.PutObjectResult>`
         """
         headers = http.CaseInsensitiveDict(headers)
-        headers['x-oss-copy-source'] = ('/' + source_bucket_name + '/' + source_key).encode('utf-8')
+        headers['x-oss-copy-source'] = utils.to_bytes('/' + source_bucket_name + '/' + source_key)
 
         resp = self.__do_object('PUT', target_key, headers=headers)
 

--- a/oss2/api.py
+++ b/oss2/api.py
@@ -551,7 +551,7 @@ class Bucket(_Base):
         :return: :class:`PutObjectResult <oss2.models.PutObjectResult>`
         """
         headers = http.CaseInsensitiveDict(headers)
-        headers['x-oss-copy-source'] = '/' + source_bucket_name + '/' + source_key
+        headers['x-oss-copy-source'] = ('/' + source_bucket_name + '/' + source_key).encode('utf-8')
 
         resp = self.__do_object('PUT', target_key, headers=headers)
 

--- a/oss2/auth.py
+++ b/oss2/auth.py
@@ -71,7 +71,7 @@ class Auth(object):
         for k, v in headers.items():
             lower_key = k.lower()
             if lower_key.startswith('x-oss-'):
-                canon_headers.append((lower_key, v if hasattr(v, 'encode') else v.decode('utf-8')))
+                canon_headers.append((lower_key, utils.to_string(v)))
 
         canon_headers.sort(key=lambda x: x[0])
 

--- a/oss2/auth.py
+++ b/oss2/auth.py
@@ -71,7 +71,7 @@ class Auth(object):
         for k, v in headers.items():
             lower_key = k.lower()
             if lower_key.startswith('x-oss-'):
-                canon_headers.append((lower_key, v))
+                canon_headers.append((lower_key, v if hasattr(v, 'encode') else v.decode('utf-8')))
 
         canon_headers.sort(key=lambda x: x[0])
 

--- a/oss2/config.py
+++ b/oss2/config.py
@@ -1,0 +1,6 @@
+# -*- coding: utf-8 -*-
+
+proxies = {
+    "http": "http://username:pass@domain:port/",
+    "https": "http://username:pass@domain:port/"
+}

--- a/oss2/http.py
+++ b/oss2/http.py
@@ -14,6 +14,7 @@ import requests
 from requests.structures import CaseInsensitiveDict
 
 from . import __version__, defaults
+from . import config
 from .compat import to_bytes
 from .exceptions import RequestError
 from .utils import file_object_remaining_bytes, SizedFileAdapter
@@ -39,7 +40,9 @@ class Session(object):
                                                  params=req.params,
                                                  headers=req.headers,
                                                  stream=True,
-                                                 timeout=timeout))
+                                                 timeout=timeout,
+                                                 proxies=config.proxies
+                                                 ))
         except requests.RequestException as e:
             raise RequestError(e)
 


### PR DESCRIPTION
出现异常的python版本: 3.5.2

错误原因：由于source_key被写入了request的header中，而http.client的putheader()默认会对unicode字符串进行"latin-1"编码，导致含中文的source_key无法被编码。

解决方案：将source_key以bytes形式存入header，在生成签名时转成string使用。
