### PR TITLE
fix issue51/52/53

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+*.pyc
+.project
+.pydevproject
+.settings
+.coverage
+build
+dist

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ install:
 - pip install --upgrade mock
 script:
 - nosetests unittests/ --with-cov
-- if [ -n "$OSS_TEST_ACCESS_KEY_ID" ]; then nosetests tests/ --with-cov; fi
+- if [ -n "$OSS_TEST_ACCESS_KEY_ID" ]; then travis_wait 30 nosetests tests/ --with-cov; fi
 after_success:
 - coveralls
 env:

--- a/oss2/api.py
+++ b/oss2/api.py
@@ -550,7 +550,7 @@ class Bucket(_Base):
         :return: :class:`PutObjectResult <oss2.models.PutObjectResult>`
         """
         headers = http.CaseInsensitiveDict(headers)
-        headers['x-oss-copy-source'] = '/' + source_bucket_name + '/' + source_key
+        headers['x-oss-copy-source'] = '/' + source_bucket_name + '/' + urlquote(source_key, '')
 
         resp = self.__do_object('PUT', target_key, headers=headers)
 

--- a/oss2/http.py
+++ b/oss2/http.py
@@ -82,10 +82,10 @@ class Response(object):
 
     def read(self, amt=None):
         if amt is None:
-            content = b''
+            content_list = []
             for chunk in self.response.iter_content(_CHUNK_SIZE):
-                content += chunk
-            return content
+                content_list.append(chunk)
+            return b''.join(content_list)
         else:
             try:
                 return next(self.response.iter_content(amt))

--- a/oss2/resumable.py
+++ b/oss2/resumable.py
@@ -66,13 +66,14 @@ def resumable_upload(bucket, key, filename,
                                       headers=headers,
                                       progress_callback=progress_callback,
                                       num_threads=num_threads)
-        uploader.upload()
+        result = uploader.upload()
     else:
         with open(to_unicode(filename), 'rb') as f:
-            bucket.put_object(key, f,
+            result = bucket.put_object(key, f,
                               headers=headers,
                               progress_callback=progress_callback)
-
+    
+    return result
 
 def resumable_download(bucket, key, filename,
                        multiget_threshold=None,
@@ -420,8 +421,10 @@ class _ResumableUploader(_ResumableOperation):
 
         self._report_progress(self.size)
 
-        self.bucket.complete_multipart_upload(self.key, self.__upload_id, self.__finished_parts)
+        result = self.bucket.complete_multipart_upload(self.key, self.__upload_id, self.__finished_parts)
         self._del_record()
+        
+        return result
 
     def __producer(self, q, parts_to_upload=None):
         for part in parts_to_upload:

--- a/tests/test_object.py
+++ b/tests/test_object.py
@@ -292,6 +292,17 @@ class TestObject(OssTestCase):
         result = self.bucket.get_object(target_key)
         self.assertEqual(content, result.read())
 
+    def test_copy_object_source_with_escape(self):
+        source_key = '阿里云/加油/:?;@&=+$, /<>{}[]|/'
+        target_key = self.random_key()
+        content = random_bytes(36)
+
+        self.bucket.put_object(source_key, content)
+        self.bucket.copy_object(self.bucket.bucket_name, source_key, target_key)
+
+        result = self.bucket.get_object(target_key)
+        self.assertEqual(content, result.read())
+
     def test_update_object_meta(self):
         key = self.random_key('.txt')
         content = random_bytes(36)

--- a/tests/test_upload.py
+++ b/tests/test_upload.py
@@ -18,7 +18,10 @@ class TestUpload(OssTestCase):
 
         pathname = self._prepare_temp_file(content)
 
-        oss2.resumable_upload(self.bucket, key, pathname)
+        result = oss2.resumable_upload(self.bucket, key, pathname)
+        self.assertTrue(result is not None)
+        self.assertTrue(result.etag is not None)
+        self.assertTrue(result.request_id is not None)
 
         result = self.bucket.get_object(key)
         self.assertEqual(content, result.read())
@@ -32,7 +35,10 @@ class TestUpload(OssTestCase):
 
         pathname = self._prepare_temp_file(content)
 
-        oss2.resumable_upload(self.bucket, key, pathname, multipart_threshold=200 * 1024, part_size=None)
+        result = oss2.resumable_upload(self.bucket, key, pathname, multipart_threshold=200 * 1024, part_size=None)
+        self.assertTrue(result is not None)
+        self.assertTrue(result.etag is not None)
+        self.assertTrue(result.request_id is not None)
 
         result = self.bucket.get_object(key)
         self.assertEqual(content, result.read())


### PR DESCRIPTION
### 变更内容
- 修复：[Issue51](https://github.com/aliyun/aliyun-oss-python-sdk/issues/51)，resumable_upload的返回值从null修正为PutObjectResult
- 修复：[Issue52](https://github.com/aliyun/aliyun-oss-python-sdk/issues/52)，优化get_object方法字符串拼接方式
- 修复：[Issue53](https://github.com/aliyun/aliyun-oss-python-sdk/issues/53)，copy_object没有对source-key进行url编码
- 增加：.gitignore