### PR TITLE
use getLogger instead of logging

### DIFF
--- a/oss2/auth.py
+++ b/oss2/auth.py
@@ -8,6 +8,7 @@ import logging
 from . import utils
 from .compat import urlquote, to_bytes
 
+logger = logging.getLogger('oss2')
 
 class Auth(object):
     """用于保存用户AccessKeyId、AccessKeySecret，以及计算签名的对象。"""
@@ -47,7 +48,7 @@ class Auth(object):
     def __make_signature(self, req, bucket_name, key):
         string_to_sign = self.__get_string_to_sign(req, bucket_name, key)
 
-        logging.debug('string_to_sign={0}'.format(string_to_sign))
+        logger.debug('string_to_sign={0}'.format(string_to_sign))
 
         h = hmac.new(to_bytes(self.secret), to_bytes(string_to_sign), hashlib.sha1)
         return utils.b64encode_as_string(h.digest())
@@ -127,7 +128,7 @@ class Auth(object):
         
         p = params if params else {}
         string_to_sign = str(expiration_time) + "\n" + canon_params_str + canonicalized_resource
-        logging.debug('string_to_sign={0}'.format(string_to_sign))
+        logger.debug('string_to_sign={0}'.format(string_to_sign))
         
         h = hmac.new(to_bytes(self.secret), to_bytes(string_to_sign), hashlib.sha1)
         signature = utils.b64encode_as_string(h.digest())

--- a/oss2/resumable.py
+++ b/oss2/resumable.py
@@ -30,6 +30,7 @@ import string
 _MAX_PART_COUNT = 10000
 _MIN_PART_SIZE = 100 * 1024
 
+logger = logging.getLogger('oss2')
 
 def resumable_upload(bucket, key, filename,
                      store=None,
@@ -188,7 +189,7 @@ class _ResumableOperation(object):
 
         self.__store = store
         self.__record_key = self.__store.make_store_key(bucket.bucket_name, key, self._abspath)
-        logging.info('key is {0}'.format(self.__record_key))
+        logger.info('key is {0}'.format(self.__record_key))
 
         # protect self.__progress_callback
         self.__plock = threading.Lock()
@@ -332,20 +333,20 @@ class _ResumableDownloader(_ResumableOperation):
         try:
             for key in ('etag', 'tmp_suffix', 'abspath', 'bucket', 'key'):
                 if not isinstance(record[key], str):
-                    logging.info('{0} is not a string: {1}, but {2}'.format(key, record[key], record[key].__class__))
+                    logger.info('{0} is not a string: {1}, but {2}'.format(key, record[key], record[key].__class__))
                     return False
 
             for key in ('part_size', 'size', 'mtime'):
                 if not isinstance(record[key], int):
-                    logging.info('{0} is not an integer: {1}, but {2}'.format(key, record[key], record[key].__class__))
+                    logger.info('{0} is not an integer: {1}, but {2}'.format(key, record[key], record[key].__class__))
                     return False
 
             for key in ('parts'):
                 if not isinstance(record['parts'], list):
-                    logging.info('{0} is not a list: {1}, but {2}'.format(key, record[key], record[key].__class__))
+                    logger.info('{0} is not a list: {1}, but {2}'.format(key, record[key], record[key].__class__))
                     return False
         except KeyError as e:
-            logging.info('Key not found: {0}'.format(e.args))
+            logger.info('Key not found: {0}'.format(e.args))
             return False
 
         return True
@@ -356,7 +357,7 @@ class _ResumableDownloader(_ResumableOperation):
             record['etag'] != self.objectInfo.etag)
 
     def __finish_part(self, part):
-        logging.debug('finishing part: part_number={0}, start={1}, end={2}'.format(part.part_number, part.start, part.end))
+        logger.debug('finishing part: part_number={0}, start={1}, end={2}'.format(part.part_number, part.start, part.end))
 
         with self.__lock:
             self.__finished_parts.append(part)
@@ -464,12 +465,12 @@ class _ResumableUploader(_ResumableOperation):
             record = None
 
         if record and self.__file_changed(record):
-            logging.debug('{0} was changed, clear the record.'.format(self.filename))
+            logger.debug('{0} was changed, clear the record.'.format(self.filename))
             self._del_record()
             record = None
 
         if record and not self.__upload_exists(record['upload_id']):
-            logging.debug('{0} upload not exist, clear the record.'.format(record['upload_id']))
+            logger.debug('{0} upload not exist, clear the record.'.format(record['upload_id']))
             self._del_record()
             record = None
 
@@ -480,7 +481,7 @@ class _ResumableUploader(_ResumableOperation):
                       'abspath': self._abspath, 'bucket': self.bucket.bucket_name, 'key': self.key,
                       'part_size': part_size}
 
-            logging.debug('put new record upload_id={0} part_size={1}'.format(upload_id, part_size))
+            logger.debug('put new record upload_id={0} part_size={1}'.format(upload_id, part_size))
             self._put_record(record)
 
         self.__record = record
@@ -546,7 +547,7 @@ class _ResumableStoreBase(object):
     def get(self, key):
         pathname = self.__path(key)
 
-        logging.debug('get key={0}, pathname={1}'.format(key, pathname))
+        logger.debug('get key={0}, pathname={1}'.format(key, pathname))
 
         if not os.path.exists(pathname):
             return None
@@ -569,13 +570,13 @@ class _ResumableStoreBase(object):
         with open(to_unicode(pathname), 'w') as f:
             json.dump(value, f)
 
-        logging.debug('put key={0}, pathname={1}'.format(key, pathname))
+        logger.debug('put key={0}, pathname={1}'.format(key, pathname))
 
     def delete(self, key):
         pathname = self.__path(key)
         os.remove(pathname)
 
-        logging.debug('del key={0}, pathname={1}'.format(key, pathname))
+        logger.debug('del key={0}, pathname={1}'.format(key, pathname))
 
     def __path(self, key):
         return os.path.join(self.dir, key)
@@ -656,23 +657,23 @@ def _is_record_sane(record):
     try:
         for key in ('upload_id', 'abspath', 'key'):
             if not isinstance(record[key], str):
-                logging.info('{0} is not a string: {1}, but {2}'.format(key, record[key], record[key].__class__))
+                logger.info('{0} is not a string: {1}, but {2}'.format(key, record[key], record[key].__class__))
                 return False
 
         for key in ('size', 'part_size'):
             if not isinstance(record[key], int):
-                logging.info('{0} is not an integer: {1}'.format(key, record[key]))
+                logger.info('{0} is not an integer: {1}'.format(key, record[key]))
                 return False
 
         if not isinstance(record['mtime'], int) and not isinstance(record['mtime'], float):
-            logging.info('mtime is not a float or an integer: {0}'.format(record['mtime']))
+            logger.info('mtime is not a float or an integer: {0}'.format(record['mtime']))
             return False
 
         if not isinstance(record['parts'], list):
-            logging.info('parts is not a list: {0}'.format(record['parts'].__class__.__name__))
+            logger.info('parts is not a list: {0}'.format(record['parts'].__class__.__name__))
             return False
     except KeyError as e:
-        logging.info('Key not found: {0}'.format(e.args))
+        logger.info('Key not found: {0}'.format(e.args))
         return False
 
     return True

--- a/oss2/task_queue.py
+++ b/oss2/task_queue.py
@@ -11,6 +11,7 @@ except ImportError:
 
 import traceback
 
+logger = logging.getLogger('oss2')
 
 class TaskQueue(object):
     def __init__(self, producer, consumers):
@@ -38,7 +39,7 @@ class TaskQueue(object):
                 t.join(1)
 
         if self.__exc_info:
-            logging.debug('An exception was thrown by producer or consumer, backtrace: {0}'.format(self.__exc_stack))
+            logger.debug('An exception was thrown by producer or consumer, backtrace: {0}'.format(self.__exc_stack))
             raise self.__exc_info[1]
 
     def put(self, data):


### PR DESCRIPTION
用getLogger来替代全局的logging

> Loggers have the following attributes and methods. Note that Loggers are never instantiated directly, but always through the module-level function logging.getLogger(name). Multiple calls to getLogger() with the same name will always return a reference to the same Logger object.

不然 引用oss2的时候没法控制logging机制