### PR TITLE
use InconsistentError for content-length mismatch issue and add

### DIFF
--- a/oss2/api.py
+++ b/oss2/api.py
@@ -482,7 +482,7 @@ class Bucket(_Base):
             if result.content_length is None:
                 shutil.copyfileobj(result, f)
             else:
-                utils.copyfileobj_and_verify(result, f, result.content_length)
+                utils.copyfileobj_and_verify(result, f, result.content_length, request_id=result.request_id)
 
             return result
 

--- a/oss2/exceptions.py
+++ b/oss2/exceptions.py
@@ -16,7 +16,7 @@ from xml.parsers import expat
 from .compat import to_string
 
 
-_OSS_ERROR_TO_EXCEPTION = {} # populated at end of module
+_OSS_ERROR_TO_EXCEPTION = {}  # populated at end of module
 
 
 OSS_CLIENT_ERROR_STATUS = -1
@@ -72,8 +72,8 @@ class RequestError(OssError):
 
 
 class InconsistentError(OssError):
-    def __init__(self, message):
-        OssError.__init__(self, OSS_INCONSISTENT_ERROR_STATUS, {}, 'InconsistentError: ' + message, {})
+    def __init__(self, message, request_id=''):
+        OssError.__init__(self, OSS_INCONSISTENT_ERROR_STATUS, {'x-oss-request-id': request_id}, 'InconsistentError: ' + message, {})
 
     def __str__(self):
         error = {'status': self.status,

--- a/oss2/resumable.py
+++ b/oss2/resumable.py
@@ -285,7 +285,7 @@ class _ResumableDownloader(_ResumableOperation):
             headers = {'If-Match': self.objectInfo.etag,
                        'If-Unmodified-Since': utils.http_date(self.objectInfo.mtime)}
             result = self.bucket.get_object(self.key, byte_range=(part.start, part.end - 1), headers=headers)
-            utils.copyfileobj_and_verify(result, f, part.end - part.start)
+            utils.copyfileobj_and_verify(result, f, part.end - part.start, request_id=result.request_id)
 
         self.__finish_part(part)
 

--- a/oss2/utils.py
+++ b/oss2/utils.py
@@ -467,7 +467,9 @@ def force_rename(src, dst):
             raise
 
 
-def copyfileobj_and_verify(fsrc, fdst, expected_len, chunk_size=16*1024):
+def copyfileobj_and_verify(fsrc, fdst, expected_len,
+                           chunk_size=16*1024,
+                           request_id=''):
     """copy data from file-like object fsrc to file-like object fdst, and verify length"""
 
     num_read = 0
@@ -481,4 +483,4 @@ def copyfileobj_and_verify(fsrc, fdst, expected_len, chunk_size=16*1024):
         fdst.write(buf)
 
     if num_read != expected_len:
-        raise RequestError(IOError("IncompleteRead from source"))
+        raise InconsistentError("IncompleteRead from source", request_id)


### PR DESCRIPTION
request-id.