### PR TITLE
Support for  HTTPConnectionPool maxsize.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 .coverage
 build
 dist
+.vscode

--- a/oss2/defaults.py
+++ b/oss2/defaults.py
@@ -50,6 +50,8 @@ multiget_part_size = 10 * 1024 * 1024
 #: 缺省 Logger
 logger = logging.getLogger()
 
+#: 每个连接池缓存的连接数量 see: https://urllib3.readthedocs.io/en/1.4/pools.html
+pool_connection_numbers = multiget_num_threads
 
 def get_logger():
     return logger

--- a/oss2/defaults.py
+++ b/oss2/defaults.py
@@ -37,6 +37,9 @@ part_size = 10 * 1024 * 1024
 #: 每个Session连接池大小, 只有一个目标主机的情况下，只用1个连接池缓存连接即可
 connection_pool_size = 1
 
+#: 每个连接池缓存的连接数量, 推荐设置为线程总数量
+# see: https://urllib3.readthedocs.io/en/1.4/pools.html
+pool_connection_numbers = 10
 
 #: 对于断点下载，如果OSS文件大小大于该值就进行并行下载（multiget）
 multiget_threshold = 100 * 1024 * 1024
@@ -50,8 +53,6 @@ multiget_part_size = 10 * 1024 * 1024
 #: 缺省 Logger
 logger = logging.getLogger()
 
-#: 每个连接池缓存的连接数量 see: https://urllib3.readthedocs.io/en/1.4/pools.html
-pool_connection_numbers = multiget_num_threads + multipart_num_threads
 
 def get_logger():
     return logger

--- a/oss2/defaults.py
+++ b/oss2/defaults.py
@@ -34,8 +34,8 @@ multipart_num_threads = 1
 part_size = 10 * 1024 * 1024
 
 
-#: 每个Session连接池大小
-connection_pool_size = 10
+#: 每个Session连接池大小, 只有一个目标主机的情况下，只用1个连接池缓存连接即可
+connection_pool_size = 1
 
 
 #: 对于断点下载，如果OSS文件大小大于该值就进行并行下载（multiget）
@@ -51,7 +51,7 @@ multiget_part_size = 10 * 1024 * 1024
 logger = logging.getLogger()
 
 #: 每个连接池缓存的连接数量 see: https://urllib3.readthedocs.io/en/1.4/pools.html
-pool_connection_numbers = multiget_num_threads
+pool_connection_numbers = multiget_num_threads + multipart_num_threads
 
 def get_logger():
     return logger

--- a/oss2/http.py
+++ b/oss2/http.py
@@ -29,8 +29,9 @@ class Session(object):
         self.session = requests.Session()
 
         psize = defaults.connection_pool_size
-        self.session.mount('http://', requests.adapters.HTTPAdapter(pool_connections=psize, pool_maxsize=psize))
-        self.session.mount('https://', requests.adapters.HTTPAdapter(pool_connections=psize, pool_maxsize=psize))
+        pconnections = defaults.pool_connection_numbers
+        self.session.mount('http://', requests.adapters.HTTPAdapter(pool_connections=pconnections, pool_maxsize=psize))
+        self.session.mount('https://', requests.adapters.HTTPAdapter(pool_connections=pconnections, pool_maxsize=psize))
 
     def do_request(self, req, timeout):
         try:

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -85,7 +85,7 @@ class TestDownload(OssTestCase):
         self.__test_normal(2 * 1024 * 1024)
 
     def test_large_many_threads(self):
-        """线程数多余分片数"""
+        """线程数多于分片数"""
 
         oss2.defaults.multiget_threshold = 1024 * 1024
         oss2.defaults.multiget_part_size = 100 * 1024


### PR DESCRIPTION
`pool_connections` is for `urllib3.ConnectionPools`'s `maxsize`, while 
`pool_maxsize` is for `urllib3.PoolManager`'s `num_pools`.

I think there are differences.

For example, if threads > ConnectionPool's maxsize, some connections won't be reuse. If maxsize < threads, connections may be wasted.

urllib3 doc:

> By default, the pool will cache just one connection. If you’re planning on using such a pool in a multithreaded environment, you should set the maxsize of the pool to a higher number, such as the number of threads.

http://urllib3.readthedocs.io/en/1.2.1/pools.html