### PR TITLE
MOD: 避免污染全局 logging

### DIFF
--- a/oss2/auth.py
+++ b/oss2/auth.py
@@ -7,8 +7,8 @@ import time
 from . import utils
 from .compat import urlquote, to_bytes
 
-from .defaults import get_logger
 import logging
+logger = logging.getLogger(__name__)
 
 AUTH_VERSION_1 = 'v1'
 AUTH_VERSION_2 = 'v2'
@@ -46,7 +46,7 @@ class AuthBase(object):
 
         p = params if params else {}
         string_to_sign = str(expiration_time) + "\n" + canon_params_str + canonicalized_resource
-        get_logger().debug('string_to_sign={0}'.format(string_to_sign))
+        logger.debug('string_to_sign={0}'.format(string_to_sign))
 
         h = hmac.new(to_bytes(self.secret), to_bytes(string_to_sign), hashlib.sha1)
         signature = utils.b64encode_as_string(h.digest())
@@ -92,7 +92,7 @@ class Auth(AuthBase):
     def __make_signature(self, req, bucket_name, key):
         string_to_sign = self.__get_string_to_sign(req, bucket_name, key)
 
-        get_logger().debug('string_to_sign={0}'.format(string_to_sign))
+        logger.debug('string_to_sign={0}'.format(string_to_sign))
 
         h = hmac.new(to_bytes(self.secret), to_bytes(string_to_sign), hashlib.sha1)
         return utils.b64encode_as_string(h.digest())
@@ -152,7 +152,7 @@ class Auth(AuthBase):
             return k + '=' + v
         else:
             return k
-    
+
 
 class AnonymousAuth(object):
     """用于匿名访问。
@@ -166,10 +166,10 @@ class AnonymousAuth(object):
 
     def _sign_url(self, req, bucket_name, key, expires):
         return req.url + '?' + '&'.join(_param_to_quoted_query(k, v) for k, v in req.params.items())
-    
+
     def _sign_rtmp_url(self, url, bucket_name, channel_name, playlist_name, expires, params):
         return url + '?' + '&'.join(_param_to_quoted_query(k, v) for k, v in params.items())
-        
+
 
 class StsAuth(object):
     """用于STS临时凭证访问。可以通过官方STS客户端获得临时密钥（AccessKeyId、AccessKeySecret）以及临时安全令牌（SecurityToken）。
@@ -295,7 +295,7 @@ class AuthV2(AuthBase):
     def __make_signature(self, req, bucket_name, key, additional_headers):
         string_to_sign = self.__get_string_to_sign(req, bucket_name, key, additional_headers)
 
-        logging.info('string_to_sign={0}'.format(string_to_sign))
+        logger.info('string_to_sign={0}'.format(string_to_sign))
 
         h = hmac.new(to_bytes(self.secret), to_bytes(string_to_sign), hashlib.sha256)
         return utils.b64encode_as_string(h.digest())
@@ -332,7 +332,7 @@ class AuthV2(AuthBase):
         else:
             encoded_uri = v2_uri_encode('/')
 
-        logging.info('encoded_uri={0} key={1}'.format(encoded_uri, key))
+        logger.info('encoded_uri={0} key={1}'.format(encoded_uri, key))
 
         return encoded_uri + self.__get_canonalized_query_string(req)
 

--- a/oss2/defaults.py
+++ b/oss2/defaults.py
@@ -8,8 +8,6 @@ oss2.defaults
 
 """
 
-import logging
-
 
 def get(value, default_value):
     if value is None:
@@ -46,10 +44,3 @@ multiget_num_threads = 4
 
 #: 并行下载（multiget）的缺省分片大小
 multiget_part_size = 10 * 1024 * 1024
-
-#: 缺省 Logger
-logger = logging.getLogger()
-
-
-def get_logger():
-    return logger

--- a/oss2/task_queue.py
+++ b/oss2/task_queue.py
@@ -2,8 +2,9 @@
 
 import threading
 import sys
+import logging
 
-from .defaults import get_logger
+logger = logging.getLogger(__name__)
 
 try:
     import Queue as queue
@@ -39,7 +40,7 @@ class TaskQueue(object):
                 t.join(1)
 
         if self.__exc_info:
-            get_logger().debug('An exception was thrown by producer or consumer, backtrace: {0}'.format(self.__exc_stack))
+            logger.debug('An exception was thrown by producer or consumer, backtrace: {0}'.format(self.__exc_stack))
             raise self.__exc_info[1]
 
     def put(self, data):

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,5 +1,4 @@
-# __init__
 from . import common
-
 import logging
+
 logging.basicConfig(level=logging.DEBUG)

--- a/tests/common.py
+++ b/tests/common.py
@@ -4,12 +4,7 @@ import string
 import unittest
 import time
 import tempfile
-import errno
-import logging
-
 import oss2
-
-logging.basicConfig(level=logging.DEBUG)
 
 OSS_ID = os.getenv("OSS_TEST_ACCESS_KEY_ID")
 OSS_SECRET = os.getenv("OSS_TEST_ACCESS_KEY_SECRET")

--- a/tests/test_api_base.py
+++ b/tests/test_api_base.py
@@ -5,7 +5,7 @@ import oss2
 import socket
 import sys
 
-from common import *
+from .common import *
 
 
 class TestApiBase(OssTestCase):

--- a/tests/test_bucket.py
+++ b/tests/test_bucket.py
@@ -3,7 +3,7 @@
 
 import datetime
 
-from common import *
+from .common import *
 from oss2 import to_string
 
 

--- a/tests/test_chinese.py
+++ b/tests/test_chinese.py
@@ -6,7 +6,7 @@ import oss2
 
 from oss2 import to_bytes, to_string
 
-from common import *
+from .common import *
 
 
 class TestChinese(OssTestCase):

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -11,7 +11,7 @@ import tempfile
 from mock import patch
 from functools import partial
 
-from common import *
+from .common import *
 
 
 class SizedFileAdapterForMock(object):

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -5,7 +5,7 @@ import sys
 import oss2
 import json
 
-from common import *
+from .common import *
 
 
 class TestImage(OssTestCase):

--- a/tests/test_iterator.py
+++ b/tests/test_iterator.py
@@ -5,7 +5,7 @@ import hashlib
 
 import oss2
 
-from common import *
+from .common import *
 from oss2 import to_string
 
 

--- a/tests/test_live_channel.py
+++ b/tests/test_live_channel.py
@@ -4,7 +4,7 @@ import os, sys
 parentdir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 sys.path.insert(0, parentdir)
 
-from common import *
+from .common import *
 from oss2.exceptions import *
 
 

--- a/tests/test_multipart.py
+++ b/tests/test_multipart.py
@@ -3,7 +3,7 @@
 import unittest
 import oss2
 
-from common import *
+from .common import *
 
 
 class TestMultipart(OssTestCase):

--- a/tests/test_object.py
+++ b/tests/test_object.py
@@ -8,7 +8,7 @@ import base64
 
 from oss2.exceptions import (ClientError, RequestError, NoSuchBucket,
                              NotFound, NoSuchKey, Conflict, PositionNotEqualToLength, ObjectNotAppendable)
-from common import *
+from .common import *
 
 
 def now():

--- a/tests/test_sts.py
+++ b/tests/test_sts.py
@@ -2,7 +2,7 @@
 
 import requests
 
-from common import *
+from .common import *
 
 if oss2.compat.is_py2:
     from aliyunsdkcore import client

--- a/tests/test_upload.py
+++ b/tests/test_upload.py
@@ -6,7 +6,7 @@ import os
 import sys
 import time
 
-from common import *
+from .common import *
 
 from mock import patch
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -12,9 +12,7 @@ import requests
 import datetime
 import locale
 
-from common import *
-
-import logging
+from .common import *
 
 try:
     xrange
@@ -117,30 +115,6 @@ class TestUtils(OssTestCase):
         progress_adapter = oss2.utils.make_progress_adapter(crc_adapter, progress_callback)
 
         self.assertEqual(progress_adapter.len, 3)
-
-    def test_default_logger_basic(self):
-        # verify default logger
-        self.assertEqual(oss2.defaults.get_logger(), logging.getLogger())
-
-        # verify custom logger
-        custom_logger = logging.getLogger('oss2')
-        oss2.defaults.logger = custom_logger
-
-        self.assertEqual(oss2.defaults.get_logger(), custom_logger)
-
-    def test_default_logger_put(self):
-        custom_logger = logging.getLogger('oss2')
-        oss2.defaults.logger = custom_logger
-
-        custom_logger.addHandler(logging.StreamHandler(sys.stdout))
-        custom_logger.setLevel(logging.DEBUG)
-
-        key = self.random_key()
-
-        self.bucket.put_object(key, 'abc')
-        resp = self.bucket.get_object(key).resp
-
-        self.assertEqual(b'abc', resp.read())
 
     def test_http_to_unixtime_in_zh_CN_locale(self):
         time_string = 'Sat, 06 Jan 2018 00:00:00 GMT'


### PR DESCRIPTION
模块里面的 logger 应该是 logging.getLogger(__name__)
用全局 logging 会导致别人用的时候没办法针对 oss 进行 log 级别等设置

参考 Python 官方实践: https://docs.python.org/2/howto/logging.html#advanced-logging-tutorial