### PR TITLE
Do not override user's custom logger level

### DIFF
--- a/oss2/__init__.py
+++ b/oss2/__init__.py
@@ -38,8 +38,7 @@ def set_file_logger(file_path, name="oss2", level=logging.INFO, format_string=No
     if not format_string:
         format_string = "%(asctime)s %(name)s [%(levelname)s] %(thread)d : %(message)s"
     logger = logging.getLogger(name)
-    if logger.level == logging.NOTSET:
-        logger.setLevel(level)
+    logger.setLevel(level)
     fh = logging.FileHandler(file_path)
     fh.setLevel(level)
     formatter = logging.Formatter(format_string)
@@ -52,8 +51,7 @@ def set_stream_logger(name='oss2', level=logging.DEBUG, format_string=None):
     if not format_string:
         format_string = "%(asctime)s %(name)s [%(levelname)s] %(thread)d : %(message)s"
     logger = logging.getLogger(name)
-    if logger.level == logging.NOTSET:
-        logger.setLevel(level)
+    logger.setLevel(level)
     fh = logging.StreamHandler()
     fh.setLevel(level)
     formatter = logging.Formatter(format_string)
@@ -61,4 +59,4 @@ def set_stream_logger(name='oss2', level=logging.DEBUG, format_string=None):
     logger.addHandler(fh)
 
 
-set_stream_logger('oss2', logging.INFO)
+set_stream_logger('oss2', logger.level or logging.INFO)

--- a/oss2/__init__.py
+++ b/oss2/__init__.py
@@ -38,7 +38,8 @@ def set_file_logger(file_path, name="oss2", level=logging.INFO, format_string=No
     if not format_string:
         format_string = "%(asctime)s %(name)s [%(levelname)s] %(thread)d : %(message)s"
     logger = logging.getLogger(name)
-    logger.setLevel(level)
+    if logger.level == logging.NOTSET:
+        logger.setLevel(level)
     fh = logging.FileHandler(file_path)
     fh.setLevel(level)
     formatter = logging.Formatter(format_string)
@@ -51,7 +52,8 @@ def set_stream_logger(name='oss2', level=logging.DEBUG, format_string=None):
     if not format_string:
         format_string = "%(asctime)s %(name)s [%(levelname)s] %(thread)d : %(message)s"
     logger = logging.getLogger(name)
-    logger.setLevel(level)
+    if logger.level == logging.NOTSET:
+        logger.setLevel(level)
     fh = logging.StreamHandler()
     fh.setLevel(level)
     formatter = logging.Formatter(format_string)


### PR DESCRIPTION
Since v2.6.0 introduced more detailed logging which default level is INFO, the logging is enabled by default.

However, this feature can only be disabled after oss2 is initialized such as by ```logging.getLogger('oss2').setLevel(logging.ERROR)```. Sometimes such as in django oss2's logging configurations is setup in ```LOGGING``` in ```settings.py``` which is before initialization of ```oss2```. Then the logging level in django for oss2 can never be changed.

This PR adds the ability to respect user's custom oss2 logging level.

## The FIXES

The default level of logger is ```logging.NOTSET``` which is actually ```0```. This PR only sets INFO level when current oss2 level is ```0```.