### PR TITLE
fix doc style

### DIFF
--- a/README-CN.rst
+++ b/README-CN.rst
@@ -9,7 +9,7 @@ Aliyun OSS SDK for Python
     :target: https://coveralls.io/github/aliyun/aliyun-oss-python-sdk?branch=master
 
 `README of English <https://github.com/aliyun/aliyun-oss-python-sdk/blob/master/README.rst>`_    
-------------------
+---------------------------------------------------------------------------------------------
 
 概述
 ----

--- a/README.rst
+++ b/README.rst
@@ -9,7 +9,7 @@ Alibaba Cloud OSS SDK for Python
     :target: https://coveralls.io/github/aliyun/aliyun-oss-python-sdk?branch=master
 
 `README of Chinese <https://github.com/aliyun/aliyun-oss-python-sdk/blob/master/README-CN.rst>`_    
-------------------
+------------------------------------------------------------------------------------------------
 
 Overview
 --------


### PR DESCRIPTION
之前因为ReadME的格式问题导致无法通过twine把包发到pypi上去，在如下方式修改后可正常发送，另外将README.rst由CRLF转变为LF