### PR TITLE
Add qosinfo api & tests & examples.

### DIFF
--- a/examples/live_channel.py
+++ b/examples/live_channel.py
@@ -103,5 +103,9 @@ bucket.post_vod_playlist(channel_name,
                          start_time = start_time,
                          end_time = end_time)
 
+# 如果想查看指定时间段内的播放列表，可以使用get_vod_playlist
+result = bucket.get_vod_playlist(channel_name, start_time=start_time, end_time=end_time)
+print("playlist:", result.playlist)
+
 # 如果一个直播频道已经不打算再使用了，那么可以调用delete_live_channel来删除频道。
 bucket.delete_live_channel(channel_name)

--- a/examples/qos_info.py
+++ b/examples/qos_info.py
@@ -1,0 +1,71 @@
+# -*- coding: utf-8 -*-
+
+import os
+import oss2
+from oss2.models import BucketQosInfo
+
+# 以下代码展示User以及Bucket的QoSInfo的操作示例
+
+# 首先初始化AccessKeyId、AccessKeySecret、Endpoint等信息。
+# 通过环境变量获取，或者把诸如“<你的AccessKeyId>”替换成真实的AccessKeyId等。
+access_key_id = os.getenv('OSS_TEST_ACCESS_KEY_ID', '<你的AccessKeyId>')
+access_key_secret = os.getenv('OSS_TEST_ACCESS_KEY_SECRET', '<你的AccessKeySecret>')
+bucket_name = os.getenv('OSS_TEST_BUCKET', '<你要请求的Bucket名称>')
+endpoint = os.getenv('OSS_TEST_ENDPOINT', '<你的访问域名>')
+
+# 确认上面的参数都填写正确了
+for param in (access_key_id, access_key_secret, bucket_name, endpoint):
+    assert '<' not in param, '请设置参数：' + param
+
+# 以下代码展示user qos info的get操作示例
+# 获取user qos info
+service = oss2.Service(oss2.Auth(access_key_id, access_key_secret), endpoint)
+user_qos_info = service.get_user_qos_info()
+print('===Get user qos info===')
+print('region:', user_qos_info.region)
+print('total_upload_bw:', user_qos_info.total_upload_bw)
+print('intranet_upload_bw:', user_qos_info.intranet_upload_bw)
+print('extranet_upload_bw:', user_qos_info.extranet_upload_bw)
+print('total_download_bw:', user_qos_info.total_download_bw)
+print('intranet_download_bw:', user_qos_info.intranet_download_bw)
+print('extranet_download_bw:', user_qos_info.extranet_download_bw)
+print('total_qps:', user_qos_info.total_qps)
+print('intranet_qps:', user_qos_info.intranet_qps)
+print('extranet_qps:', user_qos_info.extranet_qps)
+
+# 以下代码展示bucket qos info的put get delete操作示例
+# 创建Bucket对象，所有Object相关的接口都可以通过Bucket对象来进行
+bucket = oss2.Bucket(oss2.Auth(access_key_id, access_key_secret), endpoint, bucket_name)
+
+# 创建BucketQosInfo对象, -1表示不做单独限制, 具体设置规则请参考官网文档
+bucket_qos_info = BucketQosInfo(
+                    total_upload_bw = -1,
+                    intranet_upload_bw = 2,
+                    extranet_upload_bw = 2,
+                    total_download_bw = -1,
+                    intranet_download_bw = -1,
+                    extranet_download_bw = -1,
+                    total_qps = -1,
+                    intranet_qps = -1,
+                    extranet_qps = -1)
+
+# 设置bucket qos info
+result = bucket.put_bucket_qos_info(bucket_qos_info)
+print('http response status:', result.status)
+
+# 获取bucket qos info
+bucket_qos_info = bucket.get_bucket_qos_info()
+print('===Get bucket qos info===')
+print('total_upload_bw:', bucket_qos_info.total_upload_bw)
+print('intranet_upload_bw:', bucket_qos_info.intranet_upload_bw)
+print('extranet_upload_bw:', bucket_qos_info.extranet_upload_bw)
+print('total_download_bw:', bucket_qos_info.total_download_bw)
+print('intranet_download_bw:', bucket_qos_info.intranet_download_bw)
+print('extranet_download_bw:', bucket_qos_info.extranet_download_bw)
+print('total_qps:', bucket_qos_info.total_qps)
+print('intranet_qps:', bucket_qos_info.intranet_qps)
+print('extranet_qps:', bucket_qos_info.extranet_qps)
+
+# 删除bucket qos info配置
+result = bucket.delete_bucket_qos_info()
+print('http response status:', result.status)

--- a/oss2/api.py
+++ b/oss2/api.py
@@ -1979,8 +1979,7 @@ class Bucket(_Base):
         logger.debug("Start to put object tagging, bucket: {0} tagging: {1}".format(
             self.bucket_name, tagging))
 
-        if headers is not None:
-            headers = http.CaseInsensitiveDict(headers)
+        headers = http.CaseInsensitiveDict(headers)
 
         data = self.__convert_data(Tagging, xml_utils.to_put_tagging, tagging) 
         resp = self.__do_bucket('PUT', data=data, params={Bucket.TAGGING: ''}, headers=headers)

--- a/oss2/api.py
+++ b/oss2/api.py
@@ -1817,6 +1817,21 @@ class Bucket(_Base):
         logger.debug("Post vod playlist done, req_id: {0}, status_code: {1}".format(resp.request_id, resp.status))
         return RequestResult(resp)
 
+    def get_vod_playlist(self, channel_name, start_time=0, end_time=0):
+        """查看指定时间段内的播放列表
+
+        param str channel_name: 要获取点播列表的live channel的名称
+        param int start_time: 点播的起始时间，Unix Time格式，可以使用int(time.time())获取
+        param int end_time: 点播的结束时间，Unix Time格式，可以使用int(time.time())获取
+        """
+        logger.debug("Start to get vod playlist, bucket: {0}, channel_name: {1},  start_time: "
+                     "{2}, end_time: {3}".format(self.bucket_name, to_string(channel_name),  start_time, end_time))
+        resp = self.__do_object('GET', channel_name, params={Bucket.VOD: '', 'startTime': str(start_time),
+                                                     'endTime': str(end_time)})
+        logger.debug("get vod playlist done, req_id: {0}, status_code: {1}".format(resp.request_id, resp.status))
+        result = GetVodPlaylistResult(resp)
+        return result
+
     def process_object(self, key, process, headers=None):
         """处理图片的接口，支持包括调整大小，旋转，裁剪，水印，格式转换等，支持多种方式组合处理。
 

--- a/oss2/auth.py
+++ b/oss2/auth.py
@@ -73,7 +73,7 @@ class Auth(AuthBase):
          'restore', 'qos', 'referer', 'stat', 'bucketInfo', 'append', 'position', 'security-token',
          'live', 'comp', 'status', 'vod', 'startTime', 'endTime', 'x-oss-process',
          'symlink', 'callback', 'callback-var', 'tagging', 'encryption', 'versions',
-         'versioning', 'versionId', 'policy', 'requestPayment', 'x-oss-traffic-limit']
+         'versioning', 'versionId', 'policy', 'requestPayment', 'x-oss-traffic-limit', 'qosInfo']
     )
 
     def _sign_request(self, req, bucket_name, key):
@@ -132,7 +132,7 @@ class Auth(AuthBase):
 
     def __get_resource_string(self, req, bucket_name, key):
         if not bucket_name:
-            return '/'
+            return '/' + self.__get_subresource_string(req.params)
         else:
             return '/{0}/{1}{2}'.format(bucket_name, key, self.__get_subresource_string(req.params))
 

--- a/oss2/models.py
+++ b/oss2/models.py
@@ -464,8 +464,8 @@ class Owner(object):
 
 class BucketInfo(object):
     def __init__(self, name=None, owner=None, location=None, storage_class=None, intranet_endpoint=None,
-                 extranet_endpoint=None, creation_date=None, acl=None, bucket_encryption_rule=None,
-                 versioning_status=None):
+                 extranet_endpoint=None, creation_date=None, acl=None, data_redundancy_type=None, comment=None,
+                 bucket_encryption_rule=None, versioning_status=None):
         self.name = name
         self.owner = owner
         self.location = location
@@ -474,6 +474,8 @@ class BucketInfo(object):
         self.extranet_endpoint = extranet_endpoint
         self.creation_date = creation_date
         self.acl = acl
+        self.data_redundancy_type = data_redundancy_type
+        self.comment = comment
 
         self.bucket_encryption_rule = bucket_encryption_rule
         self.versioning_status = versioning_status

--- a/oss2/models.py
+++ b/oss2/models.py
@@ -1325,3 +1325,123 @@ class GetBucketRequestPaymentResult(RequestResult):
     def __init__(self, resp):
         RequestResult.__init__(self, resp)
         self.payer = ''
+
+class BucketQosInfo(object):
+    """bucket的Qos信息    
+    :以下参数如果设置为0则表示完全禁止指定类型的访问，如果为-1则表示不单独限制
+
+    :param total_upload_bw: 总上传带宽, 单位Gbps
+    :type total_upload_bw: int
+
+    :param intranet_upload_bw: 内网上传带宽, 单位Gbps
+    :type intranet_upload_bw: int
+
+    :param extranet_upload_bw: 外网上传带宽, 单位Gbps
+    :type extranet_upload_bw: int
+
+    :param total_download_bw: 总下载带宽, 单位Gbps
+    :type total_download_bw: int
+
+    :param intranet_download_bw: 内外下载带宽, 单位Gbps
+    :type intranet_download_bw: int
+
+    :param extranet_download_bw: 外网下载带宽, 单位Gbps
+    :type extranet_download_bw: int
+
+    :param total_qps: 总qps, 单位请求数/s
+    :type total_qps: int
+
+    :param intranet_qps: 内网访问qps, 单位请求数/s
+    :type intranet_qps: int
+
+    :param extranet_qps: 外网访问qps, 单位请求数/s
+    :type extranet_qps: int
+    """
+    def __init__(self,
+            total_upload_bw = None,
+            intranet_upload_bw = None,
+            extranet_upload_bw = None,
+            total_download_bw = None,
+            intranet_download_bw = None,
+            extranet_download_bw = None,
+            total_qps = None,
+            intranet_qps = None,
+            extranet_qps = None):
+
+        self.total_upload_bw = total_upload_bw
+        self.intranet_upload_bw = intranet_upload_bw
+        self.extranet_upload_bw = extranet_upload_bw
+        self.total_download_bw = total_download_bw
+        self.intranet_download_bw = intranet_download_bw
+        self.extranet_download_bw = extranet_download_bw
+        self.total_qps = total_qps
+        self.intranet_qps = intranet_qps
+        self.extranet_qps = extranet_qps
+
+class UserQosInfo(object):
+    """User的Qos信息    
+
+    :param region: 查询的qos配置生效的区域
+    :type region: str
+
+    :以下参数如果为0则表示完全禁止指定类型的访问，如果为-1表示不单独限制
+
+    :param total_upload_bw: 总上传带宽, 单位Gbps
+    :type total_upload_bw: int
+
+    :param intranet_upload_bw: 内网上传带宽, 单位:Gbps
+    :type intranet_upload_bw: int
+
+    :param extranet_upload_bw: 外网上传带宽, 单位:Gbps
+    :type extranet_upload_bw: int
+
+    :param total_download_bw: 总下载带宽, 单位:Gbps
+    :type total_download_bw: int
+
+    :param intranet_download_bw: 内外下载带宽, 单位:Gbps
+    :type intranet_download_bw: int
+
+    :param extranet_download_bw: 外网下载带宽, 单位:Gbps
+    :type extranet_download_bw: int
+
+    :param total_qps: 总qps限制
+    :type total_qps: int
+
+    :param intranet_qps: 内网访问qps
+    :type intranet_qps: int
+
+    :param extranet_qps: 外网访问qps
+    :type extranet_qps: int
+    """
+    def __init__(self, 
+            region=None,
+            total_upload_bw = None,
+            intranet_upload_bw = None,
+            extranet_upload_bw = None,
+            total_download_bw = None,
+            intranet_download_bw = None,
+            extranet_download_bw = None,
+            total_qps = None,
+            intranet_qps = None,
+            extranet_qps = None):
+
+        self.region = region
+        self.total_upload_bw = total_upload_bw
+        self.intranet_upload_bw = intranet_upload_bw
+        self.extranet_upload_bw = extranet_upload_bw
+        self.total_download_bw = total_download_bw
+        self.intranet_download_bw = intranet_download_bw
+        self.extranet_download_bw = extranet_download_bw
+        self.total_qps = total_qps
+        self.intranet_qps = intranet_qps
+        self.extranet_qps = extranet_qps
+
+class GetUserQosInfoResult(RequestResult, UserQosInfo):
+    def __init__(self, resp):
+        RequestResult.__init__(self, resp)
+        UserQosInfo.__init__(self)
+
+class GetBucketQosInfoResult(RequestResult, BucketQosInfo):
+    def __init__(self, resp):
+        RequestResult.__init__(self, resp)
+        BucketQosInfo.__init__(self)

--- a/oss2/models.py
+++ b/oss2/models.py
@@ -1148,6 +1148,10 @@ class GetLiveChannelHistoryResult(RequestResult, LiveChannelHistory):
         RequestResult.__init__(self, resp)
         LiveChannelHistory.__init__(self)
 
+class GetVodPlaylistResult(RequestResult):
+    def __init__(self, resp):
+        RequestResult.__init__(self, resp)
+        self.playlist = to_string(resp.read())
 
 class ProcessObjectResult(RequestResult):
     def __init__(self, resp):

--- a/oss2/resumable.py
+++ b/oss2/resumable.py
@@ -733,23 +733,18 @@ def make_download_store(root=None, dir=None):
     return ResumableDownloadStore(root=root, dir=dir)
 
 
-def _rebuild_record(filename, store, bucket, key, upload_id, part_size=None):
+def _rebuild_record(filename, store, bucket, key, upload_id, part_size):
     abspath = os.path.abspath(filename)
     mtime = os.path.getmtime(filename)
     size = os.path.getsize(filename)
 
     store_key = store.make_store_key(bucket.bucket_name, key, abspath)
     record = {'upload_id': upload_id, 'mtime': mtime, 'size': size, 'parts': [],
-              'abspath': abspath, 'key': key}
+              'abspath': abspath, 'key': key, 'part_size': part_size}
 
     for p in iterators.PartIterator(bucket, key, upload_id):
         record['parts'].append({'part_number': p.part_number,
                                 'etag': p.etag, 'part_crc': p.part_crc})
-
-        if not part_size:
-            part_size = p.size
-
-    record['part_size'] = part_size
 
     store.put(store_key, record)
 

--- a/oss2/xml_utils.py
+++ b/oss2/xml_utils.py
@@ -294,6 +294,8 @@ def parse_get_bucket_info(result, body):
     result.location = _find_tag(root, 'Bucket/Location')
     result.owner = Owner(_find_tag(root, 'Bucket/Owner/DisplayName'), _find_tag(root, 'Bucket/Owner/ID'))
     result.acl = AccessControlList(_find_tag(root, 'Bucket/AccessControlList/Grant'))
+    result.data_redundancy_type = _find_tag(root, 'Bucket/DataRedundancyType')
+    result.comment = _find_tag(root, 'Bucket/Comment')
 
     server_side_encryption = root.find("Bucket/ServerSideEncryptionRule")
 

--- a/oss2/xml_utils.py
+++ b/oss2/xml_utils.py
@@ -1181,3 +1181,49 @@ def parse_get_bucket_request_payment(result, body):
     result.payer = _find_tag(root, 'Payer')
    
     return result
+
+def to_put_qos_info(qos_info):
+    root = ElementTree.Element("QoSConfiguration")
+
+    if qos_info.total_upload_bw is not None:
+        _add_text_child(root, "TotalUploadBandwidth", str(qos_info.total_upload_bw))
+    if qos_info.intranet_upload_bw is not None:
+        _add_text_child(root, "IntranetUploadBandwidth", str(qos_info.intranet_upload_bw))
+    if qos_info.extranet_upload_bw is not None:
+        _add_text_child(root, "ExtranetUploadBandwidth", str(qos_info.extranet_upload_bw))
+    if qos_info.total_download_bw is not None:
+        _add_text_child(root, "TotalDownloadBandwidth", str(qos_info.total_download_bw))
+    if qos_info.intranet_download_bw is not None:
+        _add_text_child(root, "IntranetDownloadBandwidth", str(qos_info.intranet_download_bw))
+    if qos_info.extranet_download_bw is not None:
+        _add_text_child(root, "ExtranetDownloadBandwidth", str(qos_info.extranet_download_bw))
+    if qos_info.total_qps is not None:
+        _add_text_child(root, "TotalQps", str(qos_info.total_qps))
+    if qos_info.intranet_qps is not None:
+        _add_text_child(root, "IntranetQps", str(qos_info.intranet_qps))
+    if qos_info.extranet_qps is not None:
+        _add_text_child(root, "ExtranetQps", str(qos_info.extranet_qps))
+
+    return _node_to_string(root)
+
+def parse_get_qos_info(result, body):
+    """解析UserQosInfo 或者BucketQosInfo
+
+    :UserQosInfo包含成员region,其他成员同BucketQosInfo
+    """
+    root = ElementTree.fromstring(body)
+
+    if hasattr(result, 'region'):
+        result.region = _find_tag(root, 'Region')
+
+    result.total_upload_bw = _find_int(root, 'TotalUploadBandwidth')
+    result.intranet_upload_bw = _find_int(root, 'IntranetUploadBandwidth')
+    result.extranet_upload_bw = _find_int(root, 'ExtranetUploadBandwidth')
+    result.total_download_bw = _find_int(root, 'TotalDownloadBandwidth')
+    result.intranet_download_bw = _find_int(root, 'IntranetDownloadBandwidth')
+    result.extranet_download_bw = _find_int(root, 'ExtranetDownloadBandwidth')
+    result.total_qps = _find_int(root, 'TotalQps')
+    result.intranet_qps = _find_int(root, 'IntranetQps')
+    result.extranet_qps = _find_int(root, 'ExtranetQps')
+
+    return result

--- a/oss2/xml_utils.py
+++ b/oss2/xml_utils.py
@@ -212,9 +212,6 @@ def parse_list_parts(result, body):
 
 
 def parse_batch_delete_objects(result, body):
-    if not body:
-        return result
-
     root = ElementTree.fromstring(body)
     url_encoded = _is_url_encoding(root)
 
@@ -978,9 +975,7 @@ def to_select_json_object(sql, select_params):
     options = ElementTree.SubElement(root, 'Options')
     is_doc = select_params[SelectParameters.Json_Type] == SelectJsonTypes.DOCUMENT
     _add_text_child(json, 'Type', select_params[SelectParameters.Json_Type])
-    if select_params is None:
-        return _node_to_string(root)
-    
+
     for key, value in select_params.items(): 
         if SelectParameters.SplitRange == key and is_doc == False:
             _add_text_child(json, 'Range', utils._make_split_range_string(value))
@@ -1070,9 +1065,6 @@ def parse_get_tagging(result, body):
     root = ElementTree.fromstring(body)
     url_encoded = _is_url_encoding(root)
     tagset_node = root.find('TagSet')
-
-    if tagset_node is None:
-        return result
 
     tagging_rules = TaggingRule()
     for tag_node in tagset_node.findall('Tag'):

--- a/tests/common.py
+++ b/tests/common.py
@@ -51,9 +51,11 @@ def clean_and_delete_bucket(bucket):
             all_objects = bucket.list_object_versions()
             for obj in all_objects.versions:
                 bucket.delete_object(obj.key, params={'versionId': obj.versionid})
+            for del_maker in all_objects.delete_marker:
+                bucket.delete_object(del_maker.key, params={'versionId': del_maker.versionid})
     except:
         pass
-    
+
     # list all upload_parts to delete
     up_iter = oss2.MultipartUploadIterator(bucket)
     for up in up_iter:

--- a/tests/test_bucket.py
+++ b/tests/test_bucket.py
@@ -687,7 +687,7 @@ class TestBucket(OssTestCase):
 
         # KMS
         rule.sse_algorithm = oss2.SERVER_SIDE_ENCRYPTION_KMS
-        rule.kms_master_keyid = ""
+        rule.kms_master_keyid = "123"
 
         result = self.bucket.put_bucket_encryption(rule)
         self.assertEqual(int(result.status)/100, 2)
@@ -696,7 +696,7 @@ class TestBucket(OssTestCase):
 
         result = self.bucket.get_bucket_info()
         self.assertEqual(result.bucket_encryption_rule.sse_algorithm, 'KMS')
-        self.assertTrue(result.bucket_encryption_rule.kms_master_keyid is None)
+        self.assertEqual(result.bucket_encryption_rule.kms_master_keyid, '123')
 
         result = self.bucket.delete_bucket_encryption()
         self.assertEqual(int(result.status), 204)

--- a/tests/test_bucket.py
+++ b/tests/test_bucket.py
@@ -583,6 +583,8 @@ class TestBucket(OssTestCase):
         self.assertTrue(len(result.extranet_endpoint) > 0)
         self.assertTrue(len(result.owner.id) > 0)
         self.assertEqual(result.acl.grant, oss2.BUCKET_ACL_PRIVATE)
+        self.assertIsNotNone(result.data_redundancy_type)
+        self.assertIsNotNone(result.comment)
         self.assertEqual(result.bucket_encryption_rule.sse_algorithm, None)
         self.assertEqual(result.versioning_status, None)
         bucket.delete_bucket()

--- a/tests/test_bucket_versioning.py
+++ b/tests/test_bucket_versioning.py
@@ -45,7 +45,6 @@ class TestBucketVersioning(OssTestCase):
         wait_meta_sync()
 
         result = bucket.get_bucket_versioning()
-        
         self.assertTrue(result.status is None)
 
         config = BucketVersioningConfig()
@@ -55,6 +54,9 @@ class TestBucketVersioning(OssTestCase):
         self.assertEqual(int(result.status)/100, 2)
         
         wait_meta_sync()
+
+        result = bucket.get_bucket_versioning()
+        self.assertEqual(result.status, 'Enabled')
 
         result = bucket.get_bucket_info()
         self.assertEqual(result.bucket_encryption_rule.sse_algorithm, None)
@@ -146,24 +148,28 @@ class TestBucketVersioning(OssTestCase):
         self.assertEqual(result.bucket_encryption_rule.sse_algorithm, None)
         self.assertEqual(result.versioning_status, "Enabled")
 
-        for i in range(0, 50):
-            bucket.put_object("test", "test"+str(i))
+        bucket.put_object("test_dir/sub_dir1/test_object", "test-subdir-content")
+        bucket.put_object("test_dir/sub_dir2/test_object", "test-subdir-content")
 
+        for i in range(0, 50):
+            bucket.put_object("test_dir/test_object", "test"+str(i))
+
+        versions_count = 0
+        common_prefixes_count = 0
         loop_time = 0
         next_key_marker = ''
         next_version_marker = ''
-        delete_versions = []
 
+        # List object versions truncated with prefix and delimiter arguments.
         while True:
-
-            result = bucket.list_object_versions(max_keys=20, key_marker=next_key_marker, versionid_marker=next_version_marker)
+            # It will list objects that under test_dir, and not contains subdirectorys
+            result = bucket.list_object_versions(max_keys=20, prefix='test_dir/', delimiter='/', key_marker=next_key_marker, versionid_marker=next_version_marker)
             self.assertTrue(len(result.versions) > 0)
             self.assertTrue(len(result.delete_marker) == 0)
-            version_list = BatchDeleteObjectVersionList()
-            for item in result.versions:
-                version_list.append(BatchDeleteObjectVersion(item.key, item.versionid))
-            delete_versions.append(version_list)
-            
+
+            versions_count += len(result.versions)
+            common_prefixes_count += len(result.common_prefix)
+
             if result.is_truncated:
                 next_key_marker = result.next_key_marker
                 next_version_marker = result.next_versionid_marker
@@ -173,9 +179,22 @@ class TestBucketVersioning(OssTestCase):
             loop_time += 1
             if loop_time > 12:
                 self.assertFalse(True, "loop too much times, break")
-        
-        for item in delete_versions:
-            result = bucket.delete_object_versions(item)
+
+        self.assertEqual(versions_count, 50)
+        self.assertEqual(common_prefixes_count, 2)
+
+        # Create a delete marker
+        bucket.delete_object("test_dir/sub_dir1/test_object")
+
+        # List all objects to delete, and it will contains 52 objects and 1 delete marker.
+        all_objects = bucket.list_object_versions()
+        self.assertEqual(len(all_objects.versions), 52)
+        self.assertEqual(len(all_objects.delete_marker), 1)
+
+        for obj in all_objects.versions:
+            bucket.delete_object(obj.key, params={'versionId': obj.versionid})
+        for del_maker in all_objects.delete_marker:
+            bucket.delete_object(del_maker.key, params={'versionId': del_maker.versionid})
 
         try:
             bucket.delete_bucket()

--- a/tests/test_live_channel.py
+++ b/tests/test_live_channel.py
@@ -228,7 +228,28 @@ class TestLiveChannel(OssTestCase):
                           end_time = end_time)
 
         self.bucket.delete_live_channel(channel_name)
+
+    def test_get_vod_playlist(self):
+        channel_name = 'test-post-vod-playlist'
         
+        channel_target = oss2.models.LiveChannelInfoTarget()
+        channel_info = oss2.models.LiveChannelInfo(target = channel_target)
+        self.bucket.create_live_channel(channel_name, channel_info)
+
+        # push rtmp stream here, then generate some ts files on oss.
+
+        end_time = int(time.time()) - 60
+        start_time = end_time - 3600
+
+        # throw exception because no ts file been generated.
+        self.assertRaises(oss2.exceptions.InvalidArgument,
+                          self.bucket.get_vod_playlist,
+                          channel_name,
+                          start_time = start_time,
+                          end_time = end_time)
+
+        self.bucket.delete_live_channel(channel_name)
+
     def test_sign_rtmp_url(self):
         channel_name = 'test-sign-rtmp-url'
         playlist_name = 'test.m3u8'

--- a/tests/test_object_versioning.py
+++ b/tests/test_object_versioning.py
@@ -1002,6 +1002,29 @@ class TestObjectVersioning(OssTestCase):
         bucket.delete_object(key, params={'versionId': version2})
         bucket.delete_bucket()
 
+    def test_delete_object_versions_with_invalid_arguments(self):
+        from oss2.models import BucketVersioningConfig
+        from oss2.models import BatchDeleteObjectVersion
+        from oss2.models import BatchDeleteObjectVersionList
+
+        auth = oss2.Auth(OSS_ID, OSS_SECRET)
+        bucket_name = OSS_BUCKET + "test-delete-object-versions"
+        bucket = oss2.Bucket(auth, self.endpoint, bucket_name)
+        bucket.create_bucket(oss2.BUCKET_ACL_PRIVATE)
+
+        config = BucketVersioningConfig()
+        config.status = 'Enabled'
+        bucket.put_bucket_versioning(config)
+
+        wait_meta_sync()
+
+        version_list = BatchDeleteObjectVersionList()
+        version_list.append(BatchDeleteObjectVersion('test-key', '234'))
+
+        self.assertRaises(oss2.exceptions.InvalidArgument, bucket.delete_object_versions, version_list)
+        self.assertRaises(oss2.exceptions.ClientError, bucket.delete_object_versions, None)
+        self.assertRaises(oss2.exceptions.ClientError, bucket.delete_object_versions, [])
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_qos_info.py
+++ b/tests/test_qos_info.py
@@ -1,0 +1,134 @@
+# -*- coding: utf-8 -*-
+
+from .common import *
+from oss2.models import UserQosInfo, BucketQosInfo
+
+class TestQosInfo(OssTestCase):
+    def test_get_user_qos_info(self):
+        service = oss2.Service(oss2.Auth(OSS_ID, OSS_SECRET), OSS_ENDPOINT)
+
+        result = service.get_user_qos_info()
+        self.assertEqual(result.status, 200)
+        self.assertTrue(result.region is not None)
+        self.assertTrue(result.total_upload_bw is not None)
+        self.assertTrue(result.intranet_upload_bw is not None)
+        self.assertTrue(result.extranet_upload_bw is not None)
+        self.assertTrue(result.total_download_bw is not None)
+        self.assertTrue(result.intranet_download_bw is not None)
+        self.assertTrue(result.extranet_download_bw is not None)
+        self.assertTrue(result.total_qps is not None)
+        self.assertTrue(result.intranet_qps is not None)
+        self.assertTrue(result.extranet_qps is not None)
+
+    def test_put_bucket_qos_info_with_all_args(self):
+        bucket_qos_info = BucketQosInfo(
+                    total_upload_bw = -1,
+                    intranet_upload_bw = 2,
+                    extranet_upload_bw = 2,
+                    total_download_bw = -1,
+                    intranet_download_bw = -1,
+                    extranet_download_bw = -1,
+                    total_qps = -1,
+                    intranet_qps = -1,
+                    extranet_qps = -1)
+
+        result = self.bucket.put_bucket_qos_info(bucket_qos_info)
+        self.assertEqual(result.status, 200)
+
+        result = self.bucket.get_bucket_qos_info()
+        self.assertEqual(result.status, 200)
+        self.assertEqual(result.total_upload_bw, bucket_qos_info.total_upload_bw)
+        self.assertEqual(result.intranet_upload_bw, bucket_qos_info.intranet_upload_bw)
+        self.assertEqual(result.extranet_upload_bw, bucket_qos_info.extranet_upload_bw)
+        self.assertEqual(result.total_download_bw, bucket_qos_info.total_download_bw)
+        self.assertEqual(result.intranet_download_bw, bucket_qos_info.intranet_download_bw)
+        self.assertEqual(result.extranet_download_bw, bucket_qos_info.extranet_download_bw)
+        self.assertEqual(result.total_qps, bucket_qos_info.total_qps)
+        self.assertEqual(result.intranet_qps, bucket_qos_info.intranet_qps)
+        self.assertEqual(result.extranet_qps, bucket_qos_info.extranet_qps)
+
+        result = self.bucket.delete_bucket_qos_info()
+        self.assertEqual(result.status, 204)
+
+    def test_put_bucket_qos_info_with_none_args(self):
+        bucket_qos_info = BucketQosInfo()
+
+        # put bucket qos info without args setting, the default value of -1 will be returned.
+        result = self.bucket.put_bucket_qos_info(bucket_qos_info)
+        self.assertEqual(result.status, 200)
+
+        result = self.bucket.get_bucket_qos_info()
+        self.assertEqual(result.total_upload_bw, -1)
+        self.assertEqual(result.intranet_upload_bw, -1)
+        self.assertEqual(result.extranet_upload_bw, -1)
+        self.assertEqual(result.total_download_bw, -1)
+        self.assertEqual(result.intranet_download_bw, -1)
+        self.assertEqual(result.extranet_download_bw, -1)
+        self.assertEqual(result.total_qps, -1)
+        self.assertEqual(result.intranet_qps, -1)
+        self.assertEqual(result.extranet_qps, -1)
+
+        result = self.bucket.delete_bucket_qos_info()
+        self.assertEqual(result.status, 204)
+
+    def test_put_bucket_qos_info_illegal_args(self):
+        service = oss2.Service(oss2.Auth(OSS_ID, OSS_SECRET), OSS_ENDPOINT)
+        user_qos_info = service.get_user_qos_info()
+        self.assertTrue(user_qos_info.total_upload_bw > 0, 'user_qos_info.total_upload_bw should be > 0')
+        self.assertTrue(user_qos_info.total_download_bw > 0, 'user_qos_info.total_download_bw should be > 0')
+        self.assertTrue(user_qos_info.total_qps > 0, 'user_qos_info.total_qps should be > 0')
+
+        # total_upload_bw > user_qos_info.total_upload_bw, should be failed.
+        total_upload_bw = user_qos_info.total_upload_bw + 1
+        bucket_qos_info = BucketQosInfo(total_upload_bw=total_upload_bw)
+        self.assertRaises(oss2.exceptions.InvalidArgument, self.bucket.put_bucket_qos_info, bucket_qos_info)
+
+        # intranet_upload_bw > total_upload_bw, should be failed.
+        total_upload_bw = user_qos_info.total_upload_bw
+        intranet_upload_bw = total_upload_bw + 1
+        bucket_qos_info = BucketQosInfo(total_upload_bw=total_upload_bw, intranet_upload_bw=intranet_upload_bw)
+        self.assertRaises(oss2.exceptions.InvalidArgument, self.bucket.put_bucket_qos_info, bucket_qos_info)
+
+        # extranet_upload_bw > total_upload_bw, should be failed.
+        total_upload_bw = user_qos_info.total_upload_bw
+        extranet_upload_bw = total_upload_bw + 1
+        bucket_qos_info = BucketQosInfo(total_upload_bw, extranet_upload_bw=extranet_upload_bw)
+        self.assertRaises(oss2.exceptions.InvalidArgument, self.bucket.put_bucket_qos_info, bucket_qos_info)
+
+        # total_download_bw > user_qos_info.total_upload_bw, should be failed.
+        total_download_bw = user_qos_info.total_download_bw + 1
+        bucket_qos_info = BucketQosInfo(total_download_bw=total_download_bw)
+        self.assertRaises(oss2.exceptions.InvalidArgument, self.bucket.put_bucket_qos_info, bucket_qos_info)
+
+        # intranet_download_bw > total_download_bw, should be failed.
+        total_download_bw = user_qos_info.total_download_bw
+        intranet_download_bw = total_download_bw + 1
+        bucket_qos_info = BucketQosInfo(total_download_bw=total_download_bw, intranet_download_bw=intranet_download_bw)
+        self.assertRaises(oss2.exceptions.InvalidArgument, self.bucket.put_bucket_qos_info, bucket_qos_info)
+
+        # extranet_download_bw > total_download_bw, should be failed.
+        total_download_bw = user_qos_info.total_download_bw
+        extranet_download_bw = total_download_bw + 1
+        bucket_qos_info = BucketQosInfo(total_download_bw=total_download_bw, extranet_download_bw=extranet_download_bw)
+        self.assertRaises(oss2.exceptions.InvalidArgument, self.bucket.put_bucket_qos_info, bucket_qos_info)
+
+        # total_qps > user_qos_info.total_qps, should be failed.
+        total_qps = user_qos_info.total_qps + 1
+        bucket_qos_info = BucketQosInfo(total_qps=total_qps)
+        self.assertRaises(oss2.exceptions.InvalidArgument, self.bucket.put_bucket_qos_info, bucket_qos_info)
+
+        # intranet_qps > total_qps, should be failed.
+        total_qps = total_qps
+        intranet_qps = total_qps + 1
+        bucket_qos_info = BucketQosInfo(total_qps=total_qps, intranet_qps=intranet_qps)
+        self.assertRaises(oss2.exceptions.InvalidArgument, self.bucket.put_bucket_qos_info, bucket_qos_info)
+
+        # extranet_qps > total_qps, should be failed.
+        total_qps = total_qps
+        extranet_qps = total_qps + 1
+        bucket_qos_info = BucketQosInfo(extranet_qps=extranet_qps)
+        self.assertRaises(oss2.exceptions.InvalidArgument, self.bucket.put_bucket_qos_info, bucket_qos_info)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_website.py
+++ b/tests/test_website.py
@@ -1,9 +1,7 @@
 # -*- coding: utf-8 -*-
 
-import unittest
 import oss2
 from oss2 import to_string
-
 from .common import *
 from oss2.models import (ConditionInlcudeHeader, 
                         Condition, 
@@ -19,9 +17,7 @@ from oss2.models import (ConditionInlcudeHeader,
 
 
 class TestWebsite(OssTestCase):
-    
     def test_normal_set_website_without_routing_rule(self):
-
         key = self.random_key('/')
         content = random_bytes(32)
 
@@ -77,7 +73,7 @@ class TestWebsite(OssTestCase):
 
         # direct type Mirror
         redirect1 = Redirect(redirect_type='Mirror', mirror_url='http://www.test.com/', mirror_pass_query_string=True, 
-                            mirror_follow_redirect=True, mirror_check_md5=False, mirror_headers=mirror_header)
+                            mirror_follow_redirect=True, mirror_check_md5=False)
         
         redirect2 = Redirect(redirect_type='Mirror', pass_query_string=False, mirror_url='http://www.test.com/', 
                             mirror_url_slave='http://www.slave.com/', mirror_url_probe='http://www.test.com/index.html', 
@@ -128,6 +124,9 @@ class TestWebsite(OssTestCase):
             self.assertEqual(t_redirect.mirror_check_md5, cmp_redirect.mirror_check_md5)
 
             #check redirect mirror_headers
+            if cmp_redirect.mirror_headers is None:
+                continue
+
             t_mirror_headers = t_redirect.mirror_headers
             cmp_mirror_headers = cmp_redirect.mirror_headers
             self.assertEqual(t_mirror_headers.pass_all, cmp_mirror_headers.pass_all)
@@ -135,7 +134,7 @@ class TestWebsite(OssTestCase):
             self.assertEqual(len(t_mirror_headers.remove_list), len(cmp_mirror_headers.remove_list))
             self.assertEqual(len(t_mirror_headers.set_list), len(cmp_mirror_headers.set_list))
 
-            self.bucket.delete_bucket_website()  
+        self.bucket.delete_bucket_website() 
 
     def test_normal_set_website_with_alicdn_external_internal(self):
         index_file = 'index.html'

--- a/unittests/test_resumable.py
+++ b/unittests/test_resumable.py
@@ -2,6 +2,7 @@
 
 import unittest
 import oss2
+import os
 
 
 class TestResumable(unittest.TestCase):
@@ -14,9 +15,26 @@ class TestResumable(unittest.TestCase):
         n = 10000
         size = (oss2.defaults.part_size + 1) * n
         part_size = oss2.determine_part_size(size)
+        self.assertEqual((n * part_size), size)
+        self.assertEqual(part_size, (oss2.defaults.part_size+1))
 
-        self.assertTrue(n * part_size <= size)
+        n = 10000
+        size = (oss2.defaults.part_size * n) + 5
+        part_size = oss2.determine_part_size(size)
+        self.assertTrue((n * part_size) > size)
         self.assertTrue(oss2.defaults.part_size < part_size)
+
+    def test_resumable_store_dir(self):
+        root = "./"
+        store_dir = "test-resumable-store-dir"
+        path = root + store_dir
+
+        self.assertFalse(os.path.exists(path))
+        store = oss2.ResumableStore(root, store_dir)
+        self.assertTrue(os.path.exists(path))
+        self.assertTrue(os.path.isdir(path))
+
+        os.rmdir(path)
 
 
 if __name__ == '__main__':

--- a/unittests/test_select_object.py
+++ b/unittests/test_select_object.py
@@ -234,6 +234,12 @@ class TestSelectObject(OssTestCase):
         helper.create_meta(self, do_request, head_params)
 
     @patch('oss2.Session.do_request')
+    def test_create_csv_meta_with_invalid_params(self, do_request):
+        head_params = {'InvalidParam':'\n'}
+        helper = SelectCaseHelper()
+        self.assertRaises(SelectOperationClientError, helper.create_meta, self, do_request, head_params)
+
+    @patch('oss2.Session.do_request')
     def test_select_csv(self, do_request):
         sql = "select * from ossobject limit 10"
         resp_content = b'a,b,c,d,e,f,,n,g,l,o,p'
@@ -389,6 +395,12 @@ class TestSelectObject(OssTestCase):
             helper.assertFalse()
         except SelectOperationClientError:
             print("expected error")
+
+    @patch('oss2.Session.do_request')
+    def test_select_json_with_invalid_parameters(self, do_request):
+        head_params = {'Invalid':'\n', 'Json_Type':'LINES'}
+        helper = SelectCaseHelper()
+        self.assertRaises(SelectOperationClientError, helper.create_meta, self, do_request, head_params)
 
     @patch('oss2.Session.do_request')
     def test_create_json_meta_with_params(self, do_request):

--- a/unittests/test_xml_utils.py
+++ b/unittests/test_xml_utils.py
@@ -1,0 +1,40 @@
+# -*- coding: utf-8 -*-
+
+import unittest
+import xml.etree.ElementTree as ElementTree
+from oss2.xml_utils import _find_tag, _find_bool
+
+
+class TestXmlUtils(unittest.TestCase):
+    def test_find_tag(self):
+        body = '''
+        <Test>
+            <Grant>private</Grant>
+        </Test>'''
+
+        root = ElementTree.fromstring(body)
+
+        grant = _find_tag(root, 'Grant')
+        self.assertEqual(grant, 'private')
+
+        self.assertRaises(RuntimeError, _find_tag, root, 'none_exist_tag')
+
+    def test_find_bool(self):
+        body = '''
+        <Test>
+            <BoolTag1>true</BoolTag1>
+            <BoolTag2>false</BoolTag2>
+        </Test>'''
+
+        root = ElementTree.fromstring(body)
+
+        tag1 = _find_bool(root, 'BoolTag1')
+        tag2 = _find_bool(root, 'BoolTag2')
+        self.assertEqual(tag1, True)
+        self.assertEqual(tag2, False)
+
+        self.assertRaises(RuntimeError, _find_bool, root, 'none_exist_tag')
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
1,  Add qosinfo api & tests & examples.
2, Add class member 'data_redundancy_type' and 'comment' to BucketInfo.
3, Add get vod playlist api & tests & examples.
4, Add slash-safe option to sign url api that can prevent the escape of '/' to '%2F'.
5, Update coverage of api.py & resumable.py & xml_utils.py.