### PR TITLE
Fix SyntaxWarning on Python 3.8

### DIFF
--- a/oss2/headers.py
+++ b/oss2/headers.py
@@ -40,7 +40,7 @@ OSS_TRAFFIC_LIMIT = 'x-oss-traffic-limit'
 OSS_TASK_ID = 'x-oss-task-id'
 
 class RequestHeader(dict):
-    def __init__(self, *arg, **kw): 
+    def __init__(self, *arg, **kw):
         super(RequestHeader, self).__init__(*arg, **kw)
 
     def set_server_side_encryption(self, algorithm=None, cmk_id=None):
@@ -49,9 +49,9 @@ class RequestHeader(dict):
         if OSS_SERVER_SIDE_ENCRYPTION_KEY_ID in self:
             del self[OSS_SERVER_SIDE_ENCRYPTION_KEY_ID]
 
-        if algorithm is "AES256":
+        if algorithm == "AES256":
             self[OSS_SERVER_SIDE_ENCRYPTION] = "AES256"
-        elif algorithm is "KMS":
+        elif algorithm == "KMS":
             self[OSS_SERVER_SIDE_ENCRYPTION] = "KMS"
             if cmk_id is not None:
                 self[OSS_SERVER_SIDE_ENCRYPTION_KEY_ID] = cmk_id


### PR DESCRIPTION
```
/srv/brm-api_staging/venv/lib/python3.8/site-packages/oss2/headers.py:52: SyntaxWarning: "is" with a literal. Did you mean "=="?
  if algorithm is "AES256":
/srv/brm-api_staging/venv/lib/python3.8/site-packages/oss2/headers.py:54: SyntaxWarning: "is" with a literal. Did you mean "=="?
  elif algorithm is "KMS":
```