### PR TITLE
去除 oss2 依赖 aliyun-python-sdk-core-v3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setup(
                       'crcmod>=1.7',
                       'pycryptodome>=3.4.7',
                       'aliyun-python-sdk-kms>=2.4.1',
-                      'aliyun-python-sdk-core>=2.6.2',
+                      'aliyun-python-sdk-core>=2.13.12',
                       'six'],
     include_package_data=True,
     url='http://oss.aliyun.com',

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setup(
                       'crcmod>=1.7',
                       'pycryptodome>=3.4.7',
                       'aliyun-python-sdk-kms>=2.4.1',
-                      'aliyun-python-sdk-core>=2.6.2' if sys.version_info[0] == 2 else 'aliyun-python-sdk-core-v3>=2.5.5',
+                      'aliyun-python-sdk-core>=2.6.2',
                       'six'],
     include_package_data=True,
     url='http://oss.aliyun.com',


### PR DESCRIPTION
## 问题表现

aliyun-python-sdk-core-v3 已经不再维护，如果继续依赖 aliyun-python-sdk-core-v3 包反而会带来问题：如果先安装了 aliyun-python-sdk-core 包后，再安装 oss2，这时会引入 aliyun-python-sdk-core-v3，然后因为 aliyun-python-sdk-core-v3 和 aliyun-python-sdk-core 都是占用了 aliyunsdkcore 这个模块路径，导致 aliyun-python-sdk-core-v3 会完全覆盖 aliyun-python-sdk-core 的代码，从而引发问题。

## 解决方案

在 setup.py 中不再区分 python v2 和 v3 版本，统一使用 aliyun-python-sdk-core

## 复现方法
1. 创建一个新的 python3 虚拟环境
2. 安装 sts 包`pip install aliyun-python-sdk-sts`
3. 执行 `pip freeze` 查看已安装的包：  
```
aliyun-python-sdk-core==2.13.30
aliyun-python-sdk-sts==3.0.2
cffi==1.14.4
cryptography==3.2.1
jmespath==0.10.0
pycparser==2.20
six==1.15.0
```
4. 执行 sts 验证脚本确认可用
5. 安装 oss2 `pip install oss2`
6. 执行 `pip freeze`查看已安装的包
```
aliyun-python-sdk-core==2.13.30
aliyun-python-sdk-core-v3==2.13.11
aliyun-python-sdk-kms==2.14.0
aliyun-python-sdk-sts==3.0.2
certifi==2020.12.5
cffi==1.14.4
chardet==4.0.0
crcmod==1.7
cryptography==3.2.1
idna==2.10
jmespath==0.10.0
oss2==2.13.1
pycparser==2.20
pycryptodome==3.9.9
requests==2.25.1
six==1.15.0
urllib3==1.26.2
```
7. 执行验证脚本发现找不到 cn-heyuan 的 endpoint
```
aliyunsdkcore.acs_exception.exceptions.ClientException: SDK.EndpointResolvingError No endpoint in the region 'cn-heyuan'
```

验证脚本:

```python
from aliyunsdkcore.client import AcsClient
from aliyunsdkcore.acs_exception.exceptions import ClientException
from aliyunsdkcore.acs_exception.exceptions import ServerException
from aliyunsdksts.request.v20150401.AssumeRoleRequest import AssumeRoleRequest

AK_ID = "ak_id"
AK_SECRET = "ak_secret"
REGION_ID = "cn-heyuan"
ROLE_ARN = "acs:ram::some_uid:role/some_role"
SESSION_NAME = "test"


#构建一个阿里云客户端，用于发起请求。
#构建阿里云客户端时需要设置AccessKey ID和AccessKey Secret。
client = AcsClient(AK_ID, AK_SECRET, REGION_ID)

#构建请求。
request = AssumeRoleRequest()
request.set_accept_format('json')

#设置参数。
request.set_RoleArn(ROLE_ARN)
request.set_RoleSessionName(SESSION_NAME)

#发起请求，并得到响应。
response = client.do_action_with_exception(request)
# python2:  print(response)
print(str(response, encoding='utf-8'))
```