### PR TITLE
Use https by default for endpoint

### DIFF
--- a/oss2/api.py
+++ b/oss2/api.py
@@ -2506,10 +2506,16 @@ class Bucket(_Base):
 
 
 def _normalize_endpoint(endpoint):
+    """规范化endpoint，默认启用 https 以增加安全性。该接口返回规范化后的 URL 字符串。
+
+    :param endpoint: 合法的 URL 字符串，参考 RFC 1738。
+
+    :return: 规范化后的 URL 字符串。
+    """
     url = endpoint
 
     if not endpoint.startswith('http://') and not endpoint.startswith('https://'):
-        url = 'http://' + endpoint
+        url = 'https://' + endpoint
 
     p = urlparse(url)
 


### PR DESCRIPTION
Using `https` by default is one of the security best practice rules nowadays.
Azure also have been using https by default, you can refer to [_blob_client.py](https://github.com/Azure/azure-sdk-for-python/blob/master/sdk/storage/azure-storage-blob/azure/storage/blob/_blob_client.py)
Especially, the same function `_normalize_endpoint` in `django-oss-storage` also have been updated to use `https` by default, you can refer to [django-oss-storage code](https://github.com/aliyun/django-oss-storage/blob/e4b78fd9ef39f9b969b20a603a2d2f2389253da3/django_oss_storage/backends.py#L40)

With this changes, the existing programs of customers might fail with `CERTIFICATE_VERIFY_FAILED` if they didn't specify `http://` explicitly.
To avoid surprise from customers, should broadcast developers and customers in Aliyun community and relevant developer blogs before this changes.