### PR TITLE
Remove python 3.4 from travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: python
 python:
 - 2.7
-- 3.4
 - 3.5
 - 3.6
 install:


### PR DESCRIPTION
This is to fix Travis CI failure which has been seen in all PRs since 2020!
The error message in CI job as below:
```
Collecting PyYAML (from python-coveralls)
  Downloading https:
  //files.pythonhosted.org/packages/64/c2/b80047c7ac2478f9501676c988a5411ed5572f35d1beff9cae07d321512c/PyYAML-5.3.1.tar.gz
  (269kB)
  PyYAML requires Python '>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*' but the running Python is 3.4.8
```
  The root cause of Travis CI failures is that, it will install`python-coveralls` latest version 2.9.3.
  However, on [PyPI python-coveralls 2.9.3](https://pypi.org/project/python-coveralls/2.9.3/), it has dropped Python 3.4 support.

I also have raised issue in github repository for the same.