### PR TITLE
fix: syntax warning

### DIFF
--- a/oss2/utils.py
+++ b/oss2/utils.py
@@ -153,7 +153,7 @@ def is_valid_endpoint(endpoint):
     if endpoint is None:
         return False
 
-    pattern = '^([a-zA-Z]+://)?[\w.-]+(:\d+)?$'
+    pattern = '^([a-zA-Z]+://)?[\\w.-]+(:\\d+)?$'
     if re.match(pattern, endpoint):
         return True
 


### PR DESCRIPTION
当前的正则在运行的时候会报警告，改了之后可以消除这个语法的警告 (fix: https://github.com/aliyun/aliyun-oss-python-sdk/issues/387)

```bash
.venv\Lib\site-packages\oss2\utils.py:156: SyntaxWarning: invalid escape sequence '\w'
  pattern = '^([a-zA-Z]+://)?[\w.-]+(:\d+)?$'
.venv\Lib\site-packages\oss2\api.py:516: SyntaxWarning: invalid escape sequence '\&'
  """生成签名URL。
```